### PR TITLE
High Level Functions

### DIFF
--- a/pyrefinebio/__init__.py
+++ b/pyrefinebio/__init__.py
@@ -23,8 +23,9 @@ from pyrefinebio.exceptions import (
     DownloadError
 )
 
-from pyrefinebio.hlf import (
+from pyrefinebio.high_level_functions import (
     help,
+    download_dataset,
     download_compendium,
     download_quandfile_compendium
 )

--- a/pyrefinebio/__init__.py
+++ b/pyrefinebio/__init__.py
@@ -22,3 +22,9 @@ from pyrefinebio.exceptions import (
     NotFound,
     DownloadError
 )
+
+from pyrefinebio.hlf import (
+    help,
+    download_compendium,
+    download_quandfile_compendium
+)

--- a/pyrefinebio/compendia.py
+++ b/pyrefinebio/compendia.py
@@ -1,7 +1,7 @@
 from pyrefinebio import computed_file as prb_computed_file
 
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination
+from pyrefinebio.util import create_paginated_list
 
 
 class Compendia:
@@ -51,8 +51,8 @@ class Compendia:
 
             id (int): the id for the compendium result you want to get
         """
-        result = get_by_endpoint("compendia/" + str(id))
-        return Compendia(**result)
+        response = get_by_endpoint("compendia/" + str(id)).json()
+        return Compendia(**response)
 
     @classmethod
     def search(cls, **kwargs):
@@ -80,5 +80,5 @@ class Compendia:
             latest_version (bool): True will only return the highest
                                    compendium_version for each primary_organism.
         """
-        result = get_by_endpoint("compendia", params=kwargs)
-        return generator_from_pagination(result, cls)
+        response = get_by_endpoint("compendia", params=kwargs)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/computational_result.py
+++ b/pyrefinebio/computational_result.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 from pyrefinebio.common import annotation as prb_annotation
 from pyrefinebio import transcriptome_index as prb_transcriptome_index
@@ -66,8 +66,8 @@ class ComputationalResult:
 
             id (int): The id for the computational result to be retrieved.
         """
-        result = get_by_endpoint("computational_results/" + str(id))
-        return ComputationalResult(**result)
+        response = get_by_endpoint("computational_results/" + str(id)).json()
+        return ComputationalResult(**response)
 
     @classmethod
     def search(cls, **kwargs):
@@ -83,5 +83,5 @@ class ComputationalResult:
 
             offset (int): The initial index from which to return the results.
         """
-        result = get_by_endpoint("computational_results", params=kwargs)
-        return generator_from_pagination(result, cls)
+        response = get_by_endpoint("computational_results", params=kwargs)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/computed_file.py
+++ b/pyrefinebio/computed_file.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 from pyrefinebio import computational_result as prb_computational_result
 from pyrefinebio import sample as prb_sample
@@ -76,7 +76,7 @@ class ComputedFile:
 
             id (int): the id for the computed file you want to get
         """
-        response = get_by_endpoint("computed_files/" + str(id))
+        response = get_by_endpoint("computed_files/" + str(id)).json()
         return ComputedFile(**response)
 
     @classmethod
@@ -117,5 +117,5 @@ class ComputedFile:
 
             offset (int): The initial index from which to return the results.
         """
-        result = get_by_endpoint("computed_files", params=kwargs)
-        return generator_from_pagination(result, cls)
+        response = get_by_endpoint("computed_files", params=kwargs)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -77,8 +77,11 @@ class Dataset:
             experiment (str): accession code for the Experiment related to the Samples you
                               are adding to the dataset
 
-            samples (list): list of Sample accession codes for the samples you are adding
-                            to the dataset
+                       (Experiment): Experiment object related to the Samples you are adding
+                              the dataset
+
+            samples (list): list of Sample objects or Sample accession codes for the samples
+                            you are adding to the dataset
         """
         if self.is_processing or self.is_processed:
             print("Cannot add samples to a dataset that has been processed!")

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -66,6 +66,18 @@ class Dataset:
 
 
     def add_samples(self, experiment, samples=["ALL"]):
+        """Add samples to a dataset
+
+        returns: Dataset
+
+        parameters:
+
+            experiment (str): accession code for the Experiment related to the Samples you
+                              are adding to the dataset
+
+            samples (list): list of Sample accession codes for the samples you are adding
+                            to the dataset
+        """
         if self.is_processing or self.is_processed:
             print("Cannot add samples to a dataset that has been processed!")
             return

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -76,7 +76,6 @@ class Dataset:
 
             experiment (str): accession code for the Experiment related to the Samples you
                               are adding to the dataset
-
                        (Experiment): Experiment object related to the Samples you are adding
                               the dataset
 

--- a/pyrefinebio/exceptions.py
+++ b/pyrefinebio/exceptions.py
@@ -27,6 +27,8 @@ class InvalidFilters(Exception):
 
 
 class DownloadError(Exception):
-    base_message = "Unable to download dataset"
-    def __init__(self):
-        super().__init__(self.base_message)
+    base_message = "Unable to download {0}"
+    def __init__(self, type, extra_info=None):
+        if extra_info:
+            self.base_message += "\n" + extra_info 
+        super().__init__(self.base_message.format(type))

--- a/pyrefinebio/experiment.py
+++ b/pyrefinebio/experiment.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 from pyrefinebio.common import annotation as prb_annotation
 from pyrefinebio import sample as prb_sample
@@ -96,7 +96,7 @@ class Experiment:
 
             accession code (str): the accession code for the experiment you want to get
         """
-        response = get_by_endpoint("experiments/" + accession_code)
+        response = get_by_endpoint("experiments/" + accession_code).json()
         return Experiment(**response)
 
     @classmethod
@@ -136,4 +136,4 @@ class Experiment:
             offset (int): The initial index from which to return the results.
         """
         response = get_by_endpoint("search", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/high_level_functions.py
+++ b/pyrefinebio/high_level_functions.py
@@ -46,6 +46,7 @@ def help(entity=None):
 
 def download_dataset(
     path,
+    email_address,
     dataset_dict=None,
     experiments=None,
     aggregation="EXPERIMENT",
@@ -62,6 +63,8 @@ def download_dataset(
         parameters:
 
             path (str):
+
+            email_address (str):
             
             dataset_dict (dict):
 
@@ -80,6 +83,7 @@ def download_dataset(
         )
 
     dataset = Dataset(
+        email_address=email_address,
         aggregate_by=aggregation,
         quantile_normalize=(not skip_quantile_normalization)
     )

--- a/pyrefinebio/high_level_functions.py
+++ b/pyrefinebio/high_level_functions.py
@@ -62,19 +62,34 @@ def download_dataset(
 
         parameters:
 
-            path (str):
+            path (str): the path that the Dataset should be downloaded to
 
-            email_address (str):
+            email_address (str): the email address that will be contacted with info
+                                 related to the dataset
             
-            dataset_dict (dict):
+            dataset_dict (dict): a fully formed Dataset `data` attribute in the form:
+                                 {
+                                     "Experiment": [
+                                         "Sample",
+                                         "Sample"
+                                     ]
+                                 }
+                                 use this parameter if you want to specify specific Samples
+                                 for your dataset
+                                 each part of the dict can be a pyrefinebio object or an accession
+                                 code as a string
 
-            experiments (list):
+            experiments (list): a list of Experiments that should be added to the dataset
+                                use this parameter if you only care about the Experiments - all 
+                                available samples related to each Experiment will be added  
+                                the list can contain Experiment objects or accession codes as strings
 
-            aggregation (str):
+            aggregation (str): how the Dataset should be aggregated - by `EXPERIMENT` or by `SPECIES`
 
-            transformation (str):
+            transformation (str): the transformation for the dataset - `NONE`, `MINMAX`, or `STANDARD`
 
-            skip_quantile_normalization (bool):
+            skip_quantile_normalization (bool): control whether or not the dataset should skip quantile
+                                                normalization for RNA-seq Samples
     """
     if dataset_dict and experiments:
         raise DownloadError(
@@ -116,11 +131,13 @@ def download_compendium(
 
     parameters:
 
-        path (str)
+        path (str): the path that the Compendium should be downloaded to
 
-        organism (str):
+        organism (str): the name of the Organism for the Compendium you want to 
+                        download
 
-        quant_sf_only (bool):
+        quant_sf_only (bool): true for RNA-seq Sample Compendium results or False 
+                              for quantile normalized.
 
     """
     compendia = Compendia.search(
@@ -158,8 +175,9 @@ def download_quandfile_compendium(path, organism):
 
     parameters:
 
-        path (str):
+        path (str): the path that the Compendium should be downloaded to 
 
-        organism (str): the name of the Organism 
+        organism (str): the name of the Organism for the Compendium you want to 
+                        download
     """
     download_compendium(organism, path, True)

--- a/pyrefinebio/hlf.py
+++ b/pyrefinebio/hlf.py
@@ -1,0 +1,88 @@
+import pyrefinebio
+import re
+
+from pyrefinebio import Dataset, Compendia
+from pyrefinebio.http import download_file
+from pyrefinebio.exceptions import DownloadError
+
+def help(entity=None):
+    """Help
+
+    Prints out information about pyrefinebio's classes and functions.
+    To get information about a class method, pass in the class name and method name  
+    separated by either a space or a `.`
+    
+    usage:
+
+        getting info about classes:
+
+        >>> pyrefinebio.help("Sample")
+        
+        gettting info about class methods:
+
+        >>> pyrefinebio.help("Sample.get")
+        or
+        >>> pyrefinebio.help("Sample get")
+    """
+
+    if not entity:
+        print()
+        return
+
+    try:
+        final_entity = pyrefinebio
+        for attr in re.split("[. ]", entity):
+            final_entity = getattr(final_entity, attr)
+        print(final_entity.__doc__)
+    except:
+        print("could not find class or attribute: ", entity)
+
+
+
+def download_dataset(
+    experiments=None,
+    samples=None,
+    aggregation="EXPERIMENT",
+    transformation="NONE",
+    skip_quantile_normalization=False
+):
+    dataset = Dataset(
+        aggregate_by=aggregation,
+        quantile_normalize=(not skip_quantile_normalization)
+    )
+
+    pass
+
+
+def download_compendium(
+    organism,
+    path,
+    quant_sf_only=False
+):
+    compendia = Compendia.search(
+        primary_organism__name=organism,
+        quant_sf_only=quant_sf_only,
+        latest_version=True
+    )
+
+    if not compendia:
+        raise DownloadError(
+            "Compendium", 
+            extra_info="Could not find any Compendium with organism name, {0} and quant_sf_only, {1}"
+                .format(organism, quant_sf_only)
+        )
+
+    download_url = compendia[0].computed_file.download_url
+
+    if not download_url:
+        raise DownloadError(
+            "Compendium", 
+            extra_info="No download url found. Make sure you have an activated api token set up.\n" +
+                       "See pyrefinebio.Token for more info"
+        )
+    
+    download_file(download_url, path)
+
+
+def download_quandfile_compendium(organism, path):
+    download_compendium(organism, path, True)

--- a/pyrefinebio/http.py
+++ b/pyrefinebio/http.py
@@ -26,7 +26,7 @@ def request(method, url, params=None, payload=None):
         response = requests.request(method, url, params=params, data=payload, headers=headers)
         response.raise_for_status()
 
-        return response.json()
+        return response
 
     except requests.exceptions.HTTPError:
         code = response.status_code

--- a/pyrefinebio/institution.py
+++ b/pyrefinebio/institution.py
@@ -22,5 +22,5 @@ class Institution:
 
         Since there are no filters, this method always gets all institutions.
         """
-        response = get_by_endpoint("institutions")
+        response = get_by_endpoint("institutions").json()
         return [Institution(**institution) for institution in response]

--- a/pyrefinebio/job.py
+++ b/pyrefinebio/job.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 
 class DownloaderJob:
@@ -63,7 +63,7 @@ class DownloaderJob:
 
             id (int): the id for the downloader job you want to get
         """
-        response = get_by_endpoint("jobs/downloader/" + str(id))
+        response = get_by_endpoint("jobs/downloader/" + str(id)).json()
         return DownloaderJob(**response)
 
     @classmethod
@@ -115,7 +115,7 @@ class DownloaderJob:
             nomad (str): Only return jobs that are in the nomad queue currently
         """
         response = get_by_endpoint("jobs/downloader", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)
 
 
 class ProcessorJob:
@@ -183,7 +183,7 @@ class ProcessorJob:
 
             id (int): the id for the processor job you want to get
         """
-        response = get_by_endpoint("jobs/processor/" + str(id))
+        response = get_by_endpoint("jobs/processor/" + str(id)).json()
         return ProcessorJob(**response)
 
     @classmethod
@@ -239,7 +239,7 @@ class ProcessorJob:
             nomad (string): Only return jobs that are in the nomad queue currently
         """
         response = get_by_endpoint("jobs/processor", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)
 
 
 class SurveyJob:
@@ -287,7 +287,7 @@ class SurveyJob:
 
             id (int): the id for the survey job you want to get
         """
-        response = get_by_endpoint("jobs/survey/" + str(id))
+        response = get_by_endpoint("jobs/survey/" + str(id)).json()
         return SurveyJob(**response)
 
     @classmethod
@@ -319,4 +319,4 @@ class SurveyJob:
             offset (integer): The initial index from which to return the results.
         """
         response = get_by_endpoint("jobs/survey", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/organism.py
+++ b/pyrefinebio/organism.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination
+from pyrefinebio.util import create_paginated_list
 
 
 class Organism:
@@ -38,7 +38,7 @@ class Organism:
             name (str): the name for the organism you want to get
         """
 
-        response = get_by_endpoint("organisms/" + name)
+        response = get_by_endpoint("organisms/" + name).json()
         return Organism(**response)
 
     @classmethod
@@ -50,4 +50,4 @@ class Organism:
         Since there are no filters, this method always returns all organisms
         """
         response = get_by_endpoint("organisms", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/original_file.py
+++ b/pyrefinebio/original_file.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 import pyrefinebio.job as prb_job
 import pyrefinebio.sample as prb_sample
@@ -65,7 +65,7 @@ class OriginalFile:
             id (int): the id for the original file you want to get
         """
 
-        response = get_by_endpoint("original_files/" + str(id))
+        response = get_by_endpoint("original_files/" + str(id)).json()
         return OriginalFile(**response)
 
     @classmethod
@@ -110,4 +110,4 @@ class OriginalFile:
         """
 
         response = get_by_endpoint("original_files", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/platform.py
+++ b/pyrefinebio/platform.py
@@ -27,5 +27,5 @@ class Platform:
 
         Since there are no filters, this method always returns all platforms
         """
-        response = get_by_endpoint("platforms", params=kwargs)
+        response = get_by_endpoint("platforms", params=kwargs).json()
         return [Platform(**platform) for platform in response]

--- a/pyrefinebio/processor.py
+++ b/pyrefinebio/processor.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination
+from pyrefinebio.util import create_paginated_list
 
 
 class Processor:
@@ -42,7 +42,7 @@ class Processor:
 
             id (int): the id for the processor you want to get
         """
-        response = get_by_endpoint("processors/" + str(id))
+        response = get_by_endpoint("processors/" + str(id)).json()
         return Processor(**response)
 
     @classmethod
@@ -54,4 +54,4 @@ class Processor:
         Since there are no filters, this method always returns all processors
         """
         response = get_by_endpoint("processors", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/qn_target.py
+++ b/pyrefinebio/qn_target.py
@@ -57,7 +57,7 @@ class QNTarget:
 
             organism_name (str): the name of the organism for the qn target you want to get
         """
-        response = get_by_endpoint("qn_targets/" + organism_name)
+        response = get_by_endpoint("qn_targets/" + organism_name).json()
         return QNTarget(**response)
 
     @classmethod
@@ -68,5 +68,5 @@ class QNTarget:
 
         Since there are no filters, this method always returns all organisms that have available QN targets
         """
-        response = get_by_endpoint("qn_targets", params=kwargs)
+        response = get_by_endpoint("qn_targets", params=kwargs).json()
         return [prb_organism.Organism(**qn_organism) for qn_organism in response]

--- a/pyrefinebio/sample.py
+++ b/pyrefinebio/sample.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 from pyrefinebio.common import annotation as prb_annotation
 from pyrefinebio import computational_result as prb_computational_result
@@ -127,8 +127,8 @@ class Sample:
 
             accession_code (str): The accession code for the sample to be retrieved.
         """
-        result = get_by_endpoint("samples/" + accession_code)
-        return cls(**result)
+        response = get_by_endpoint("samples/" + accession_code).json()
+        return cls(**response)
 
     @classmethod
     def search(cls, **kwargs):
@@ -175,5 +175,5 @@ class Sample:
                                              separated by commas and the endpoint will
                                              only return information about these samples.
         """
-        result = get_by_endpoint("samples", params=kwargs)
-        return generator_from_pagination(result, cls)
+        response = get_by_endpoint("samples", params=kwargs)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/token.py
+++ b/pyrefinebio/token.py
@@ -25,7 +25,7 @@ class Token:
             email_address (str): the email that the terms and conditions should be sent to.
         """
 
-        response = post_by_endpoint("token")
+        response = post_by_endpoint("token").json()
 
         token_id = response["id"]
 
@@ -48,9 +48,7 @@ class Token:
             api_token (str): the uuid string identifying the token
                              you want to activate.
         """
-
-        response = put_by_endpoint("token/" + api_token, payload={"is_activated": True})
-        return response
+        put_by_endpoint("token/" + api_token, payload={"is_activated": True})
 
     @classmethod
     def save_token(cls, api_token):

--- a/pyrefinebio/token.py
+++ b/pyrefinebio/token.py
@@ -48,7 +48,7 @@ class Token:
             api_token (str): the uuid string identifying the token
                              you want to activate.
         """
-        put_by_endpoint("token/" + api_token, payload={"is_activated": True})
+        return put_by_endpoint("token/" + api_token, payload={"is_activated": True})
 
     @classmethod
     def save_token(cls, api_token):

--- a/pyrefinebio/transcriptome_index.py
+++ b/pyrefinebio/transcriptome_index.py
@@ -1,5 +1,5 @@
 from pyrefinebio.http import get_by_endpoint
-from pyrefinebio.util import generator_from_pagination, parse_date
+from pyrefinebio.util import create_paginated_list, parse_date
 
 
 class TranscriptomeIndex:
@@ -53,7 +53,7 @@ class TranscriptomeIndex:
 
             id (int): the id for the transcriptome index you want to get
         """
-        response = get_by_endpoint("transcriptome_indices/" + str(id))
+        response = get_by_endpoint("transcriptome_indices/" + str(id)).json()
         return TranscriptomeIndex(**response)
 
     @classmethod
@@ -79,4 +79,4 @@ class TranscriptomeIndex:
             length (str): Short hand for index_type Eg. short or long
         """
         response = get_by_endpoint("transcriptome_indices", params=kwargs)
-        return generator_from_pagination(response, cls)
+        return create_paginated_list(cls, response)

--- a/pyrefinebio/util.py
+++ b/pyrefinebio/util.py
@@ -2,17 +2,8 @@ from pyrefinebio.http import get
 from dateutil import parser
 
 
-def generator_from_pagination(response, T):
-    more_results = True
-
-    while more_results:
-        for result in response["results"]:
-            yield T(**result)
-
-        if response["next"] == None:
-            more_results = False
-        else:
-            response = get(response["next"])
+def create_paginated_list(T, response):
+    return PaginatedList(T, response)
 
 def parse_date(date):
     try:
@@ -20,3 +11,73 @@ def parse_date(date):
         parsed = parser.isoparse(date)
     finally:
         return parsed
+
+
+class PaginatedList:
+
+    def __init__(self, T, response):
+        self.cur = 0
+        self.type = T
+
+        self.base_url = response.url
+
+        json = response.json()
+
+        self.total_items = json["count"]
+        self.page_size = len(json["results"])
+
+        max_pages = int(self.total_items / self.page_size) if self.page_size else 0
+
+        self.pages = [None for _ in range(max_pages + 1)]
+        self.pages[0] = [T(**item) for item in json["results"]]
+
+
+    def __getitem__(self, index):
+        if index < 0:
+            index += self.total_items
+
+        if index >= self.total_items or index < 0:
+            raise IndexError("index out of range!")
+
+        page = int(index / self.page_size)
+        page_index = index - page * self.page_size
+
+        try:
+            result = self.pages[page][page_index]
+        except:
+            params = {
+                "offset": page * self.page_size,
+                "limit": self.page_size
+            }
+
+            response = get(self.base_url, params=params).json()
+
+            if self.total_items != response["count"]:
+                raise RuntimeError("List has changed since creation!")
+
+            self.pages[page] = [self.type(**item) for item in response["results"]]
+
+            result = self.pages[page][page_index]
+        
+        return result
+
+
+    def __setitem__(self, index, value):
+        raise AttributeError("PaginatedLists are immutable")
+
+
+    def __delitem__(self, index, value):
+        raise AttributeError("PaginatedLists are immutable")
+
+
+    def __len__(self):
+        return self.total_items
+
+
+    def __next__(self):
+        if self.cur < self.total_items:
+            n = self[self.cur]
+            self.cur += 1
+            return n
+        else:
+            raise StopIteration()

--- a/pyrefinebio/util.py
+++ b/pyrefinebio/util.py
@@ -14,6 +14,12 @@ def parse_date(date):
 
 
 class PaginatedList:
+    """PaginatedList
+
+    PaginatedLists are returned by all model class `search` methods that deal
+    with paginated api responses. PaginatedLists can be indexed like lists and 
+    iterated through like generators.
+    """
 
     def __init__(self, T, response):
         self.cur = 0

--- a/tests/test_compendia.py
+++ b/tests/test_compendia.py
@@ -80,7 +80,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/compendia/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)
@@ -107,12 +107,10 @@ class CompendiaTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendia_search_no_filters(self, mock_request):
-        result = pyrefinebio.Compendia.search()
+        results = pyrefinebio.Compendia.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], compendia_object_1)
-        self.assertObject(result_list[1], compendia_object_2)
+        self.assertObject(results[0], compendia_object_1)
+        self.assertObject(results[1], compendia_object_2)
 
         self.assertEqual(len(mock_request.call_args_list), 2)
 

--- a/tests/test_computational_result.py
+++ b/tests/test_computational_result.py
@@ -141,7 +141,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/computational_results/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_computed_file.py
+++ b/tests/test_computed_file.py
@@ -186,7 +186,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/computed_files/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,7 @@
 import unittest
 import pyrefinebio
 import os
+import json
 from pyrefinebio.config import Config
 from unittest.mock import Mock, patch
 
@@ -40,6 +41,16 @@ dataset = {
 
 
 def mock_request(method, url, data, **kwargs):
+
+    if method == 'POST':
+        data = json.loads(data)
+        ds = {}
+        for key, value in dataset.items():
+            if data.get(key):
+                ds[key] = data.get(key)
+            else:
+                ds[key] = value
+        return MockResponse(ds, url)
 
     if url == "https://api.refine.bio/v1/dataset/test-dataset/":
         return MockResponse(dataset, url)
@@ -229,5 +240,3 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
                 ]
             }
         )
-
-

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -203,3 +203,31 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
         mock_copy.assert_called_with("raw", "file")
 
     
+    def test_add_samples(self):
+        dataset = pyrefinebio.Dataset()
+
+        dataset.add_samples("test-experiment-1")
+
+        experiment2 = pyrefinebio.Experiment(accession_code="test-experiment-2")
+
+        dataset.add_samples(experiment2)
+
+        sample1 = pyrefinebio.Sample(accession_code="sample1")
+        sample2 = pyrefinebio.Sample(accession_code="sample2")
+
+        dataset.add_samples("test-experiment-3", samples=[sample1, sample2, "sample3"])
+
+        self.assertDictEqual(
+            dataset.data,
+            {
+                "test-experiment-1": ["ALL"],
+                "test-experiment-2": ["ALL"],
+                "test-experiment-3": [
+                    "sample1",
+                    "sample2",
+                    "sample3"
+                ]
+            }
+        )
+
+

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -77,7 +77,8 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.dataset.post_by_endpoint")
     @patch("pyrefinebio.dataset.put_by_endpoint")
     def test_dataset_save(self, mock_put, mock_post):
-        mock_post.return_value = dataset
+        mock_post.return_value = MockResponse(dataset, "")
+        mock_put.return_value = MockResponse(dataset, "")
 
         ds = pyrefinebio.Dataset(data={"test-experiment": ["sample-1", "sample-2"]}, email_address="test-email")
         ds = ds.save()

--- a/tests/test_downloader_job.py
+++ b/tests/test_downloader_job.py
@@ -73,7 +73,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/jobs/downloader/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -149,7 +149,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/search/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_high_level_functions.py
+++ b/tests/test_high_level_functions.py
@@ -1,0 +1,148 @@
+import unittest
+import pyrefinebio
+import os
+from pyrefinebio.config import Config
+from unittest.mock import Mock, patch
+
+from tests.custom_assertions import CustomAssertions
+from tests.mocks import MockResponse
+
+
+class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
+
+    @patch("pyrefinebio.dataset.download_file")
+    @patch("pyrefinebio.dataset.get_by_endpoint")
+    @patch("pyrefinebio.dataset.post_by_endpoint")
+    def test_download_dataset_dataset_dict(self, mock_post, mock_get, mock_download):
+        mr = MockResponse(
+            {
+                "id": "test_dataset",
+                "is_processed": True,
+                "download_url": "test_url"
+            },
+            "url"
+        )
+
+        mock_get.return_value = mr
+        mock_post.return_value = mr
+
+        dataset_dict = {
+            "test": ["foo", "bar"]
+        }
+
+        pyrefinebio.download_dataset("test", "foo@test.com", dataset_dict=dataset_dict)
+
+        mock_post.assert_called_with(
+            "dataset",
+            payload={
+                "data": dataset_dict,
+                "aggregate_by": "EXPERIMENT",
+                "email_address": "foo@test.com",
+                "start": True,
+                "quantile_normalize": True
+            }
+        )
+
+        mock_download.assert_called_with("test_url", "test")
+
+
+    @patch("pyrefinebio.dataset.download_file")
+    @patch("pyrefinebio.dataset.get_by_endpoint")
+    @patch("pyrefinebio.dataset.post_by_endpoint")
+    def test_download_dataset_experiments(self, mock_post, mock_get, mock_download):
+        mr = MockResponse(
+            {
+                "id": "test_dataset",
+                "is_processed": True,
+                "download_url": "test_url"
+            },
+            "url"
+        )
+
+        mock_get.return_value = mr
+        mock_post.return_value = mr
+
+        experiment2 = pyrefinebio.Experiment(accession_code="test-experiment-2")
+
+        pyrefinebio.download_dataset("test", "foo@test.com", experiments=["test-experiment-1", experiment2])
+
+        mock_post.assert_called_with(
+            "dataset",
+            payload={
+                "data": {
+                    "test-experiment-1": ["ALL"],
+                    "test-experiment-2": ["ALL"]
+                },
+                "aggregate_by": "EXPERIMENT",
+                "email_address": "foo@test.com",
+                "start": True,
+                "quantile_normalize": True
+            }
+        )
+
+        mock_download.assert_called_with("test_url", "test")
+
+
+    def test_download_dataset_both(self):
+        with self.assertRaises(pyrefinebio.exceptions.DownloadError):
+            pyrefinebio.download_dataset("test", "foo@test.com", dataset_dict={"bad"}, experiments=["bad"])
+
+
+    @patch("pyrefinebio.high_level_functions.download_file")
+    @patch("pyrefinebio.compendia.get_by_endpoint")
+    def test_download_compendium(self, mock_get, mock_download):
+        mock_get.return_value = MockResponse(
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "computed_file": {
+                            "download_url": "test_url"
+                        }
+                    }
+                ]
+            },
+            "url"
+        )
+
+        pyrefinebio.download_compendium("test", "test_organism")
+        
+        mock_get.assert_called_with(
+            "compendia",
+            params={
+                "primary_organism__name": "test_organism",
+                "quant_sf_only": False,
+                "latest_version": True
+            }
+        )
+
+        mock_download.assert_called_with("test_url", "test")
+
+
+    def test_download_compendium_no_results(self):
+        with self.assertRaises(pyrefinebio.exceptions.DownloadError):
+            pyrefinebio.download_compendium("test", "this-will-have-no-results")
+
+
+    @patch("pyrefinebio.compendia.get_by_endpoint")
+    def test_download_compendium_no_token(self, mock_get):
+        mock_get.return_value = MockResponse(
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "computed_file": {
+                            "download_url": None
+                        }
+                    }
+                ]
+            },
+            "url"
+        )
+
+        with self.assertRaises(pyrefinebio.exceptions.DownloadError):
+            pyrefinebio.download_compendium("test", "test_organism")

--- a/tests/test_organism.py
+++ b/tests/test_organism.py
@@ -42,7 +42,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/organisms/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_original_file.py
+++ b/tests/test_original_file.py
@@ -165,7 +165,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/original_files/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -1,0 +1,98 @@
+import unittest
+import pyrefinebio
+
+from unittest.mock import Mock, patch
+
+from tests.custom_assertions import CustomAssertions
+from tests.mocks import MockResponse
+
+
+item0 = {
+    "id": 1,
+    "name": "test-1",
+    "version": 1,
+    "docker_image": "test-1",
+    "environment": "test-1"
+}
+
+item1 = {
+    "id": 2,
+    "name": "test-2",
+    "version": 1,
+    "docker_image": "test-2",
+    "environment": "test-2"
+}
+
+item2 = {
+    "id": 3,
+    "name": "test-3",
+    "version": 1,
+    "docker_image": "test-3",
+    "environment": "test-3"
+}
+
+item3 = {
+    "id": 4,
+    "name": "test-4",
+    "version": 1,
+    "docker_image": "test-4",
+    "environment": "test-4"
+}
+
+page1 = {
+    "count": 4,
+    "next": "search_2",
+    "previous": None,
+    "results": [item0, item1]
+}
+
+page2 = {
+    "count": 4,
+    "next": "search_2",
+    "previous": None,
+    "results": [item2, item3]
+}
+
+def mock_request(method, url, **kwargs):
+
+    if url == "https://api.refine.bio/v1/test/" and not kwargs:
+        return MockResponse(page1, url)
+
+    if url == "https://api.refine.bio/v1/test/" and kwargs["params"] == {"offset": 2, "limit": 2}:
+        return MockResponse(page2, url)
+        
+
+class DatasetTests(unittest.TestCase, CustomAssertions):
+
+    def setUp(self):
+        T = pyrefinebio.Processor
+        response = MockResponse(page1, "https://api.refine.bio/v1/test/")
+        self.paginatedList = pyrefinebio.util.create_paginated_list(T, response)
+
+
+    @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
+    def test_indexing(self, mock_request):
+        self.assertObject(self.paginatedList[0], item0)
+        self.assertObject(self.paginatedList[1], item1)
+        self.assertObject(self.paginatedList[2], item2)
+        self.assertObject(self.paginatedList[3], item3)
+
+        self.assertObject(self.paginatedList[-1], item3)
+        self.assertObject(self.paginatedList[-2], item2)
+
+        with self.assertRaises(IndexError):
+            self.paginatedList[4]
+
+        with self.assertRaises(IndexError):
+            self.paginatedList[-5]
+
+
+    @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
+    def test_iteration(self, mock_request):
+        actual = [item0, item1, item2, item3]
+
+        i = 0
+
+        for processor in self.paginatedList:
+            self.assertObject(processor, actual[i])
+            i += 1

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -76,7 +76,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/processors/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_processor_job.py
+++ b/tests/test_processor_job.py
@@ -79,7 +79,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/jobs/processor/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -297,13 +297,13 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/samples/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)
 
     if url == "https://api.refine.bio/v1/search/":
-        return MockResponse(e_search_1, url)
+        return MockResponse(e_search_1, "e_search_2")
 
     if url == "e_search_2":
         return MockResponse(e_search_2, url)

--- a/tests/test_survey_job.py
+++ b/tests/test_survey_job.py
@@ -52,7 +52,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/jobs/survey/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)

--- a/tests/test_transcriptome_index.py
+++ b/tests/test_transcriptome_index.py
@@ -58,7 +58,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(None, url, status=500)
 
     if url == "https://api.refine.bio/v1/transcriptome_indices/":
-        return MockResponse(search_1, url)
+        return MockResponse(search_1, "search_2")
 
     if url == "search_2":
         return MockResponse(search_2, url)
@@ -86,12 +86,10 @@ class TranscriptomeIndexTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_transcriptome_index_search_no_filters(self, mock_request):
-        result = pyrefinebio.TranscriptomeIndex.search()
+        results = pyrefinebio.TranscriptomeIndex.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], index_1)
-        self.assertObject(result_list[1], index_2)
+        self.assertObject(results[0], index_1)
+        self.assertObject(results[1], index_2)
 
         self.assertEqual(len(mock_request.call_args_list), 2)
 


### PR DESCRIPTION
## Issues:
The main issue this relates to is:
AlexsLemonade/refinebio#2545

This PR also takes care of:
#9 

## Also:
This PR also adds `PaginatedList` which can be found in `util.py`

Now, all `foo.search()` methods that deal with paginated api responses will return a `PaginatedList` of results.

Previously these methods would return generators which was fine, but sometimes when testing I found that I wanted to get the first object or index the results. This was kinda annoying with generators. `PaginatedList` can be indexed and also can be iterated like a generator.