### PR TITLE
Rework Config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,6 @@
+
+Config
+=======
+
+.. autoclass:: pyrefinebio.config.Config
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ More Stuff
    :maxdepth: 2
 
    high_level_functions
-   http
+   config
    util
 
 Indices and tables

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -17,7 +17,7 @@ class Config:
         token:
             The refine.bio api token that is used when making requests
 
-            environment variable: `RB_TOKEN`
+            environment variable: `REFINEBIO_TOKEN`
 
         base_url: 
             The base url for the refine.bio api that should be used 
@@ -61,7 +61,7 @@ class Config:
                 with open(cls.config_file) as config_file:
                     config = yaml.full_load(config_file) or {}
 
-            cls.token = os.getenv("RB_TOKEN") or config.get("token", "")
+            cls.token = os.getenv("REFINEBIO_TOKEN") or config.get("token", "")
             cls.base_url = os.getenv("BASE_URL") or config.get("base_url", "https://api.refine.bio/v1/")
 
         return cls._instance

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -7,9 +7,34 @@ import yaml
 class Config:
     """Config for pyrefinebio.
 
-    When instantiated, configurations are pulled first from environment variables,  
-    then from the config file locaed at `~/.refinebio.yaml`. If neither exist, default  
-    values are used.
+    Config values can be set by environment variables or in the Config file.
+    
+    The Config file's default location is `~/.refinebio.yaml`, but this location
+    can be set by using the environment variable `CONFIG_FILE`
+
+    pyrefinebio's configurable values are:
+
+        token:
+            The refine.bio api token that is used when making requests
+
+            environment variable: `RB_TOKEN`
+
+        base_url: 
+            The base url for the refine.bio api that should be used 
+            when making requests. The default is `https://api.refine.bio/v1/`
+
+            environment variable: `BASE_URL`
+    
+    These config values can be modified directly in code, but it recommended that you
+    set them by using environment variables, by modifying them in Config file, or by 
+    using other class methods provided - like `pyrefinebio.Token` for example.
+
+    example Config file:
+
+    .. code-block:: shell
+
+        token: foo-bar-baz 
+        base_url: https://api.refine.bio/v1/
     """
 
     _instance = None
@@ -17,10 +42,11 @@ class Config:
     def __new__(cls):
         """Create an instance of config
 
-        config attributes are loaded from environment variables first, then the config file  
-        at `~/.refinebio.yaml`, then defaults
+        Config values are loaded from environment variables first, then the config file,
+        then they are set to defaults.
         
-        returns: Config
+        returns:
+            Config
         """
         if not cls._instance:
             cls._instance = super(Config, cls).__new__(cls)
@@ -35,26 +61,22 @@ class Config:
                 with open(cls.config_file) as config_file:
                     config = yaml.full_load(config_file) or {}
 
-            cls.token = config.get("token", "")
-            cls.base_url = os.getenv("BASE_URL") or config.get("base_url") or "https://api.refine.bio/v1/"
+            cls.token = os.getenv("RB_TOKEN") or config.get("token", "")
+            cls.base_url = os.getenv("BASE_URL") or config.get("base_url", "https://api.refine.bio/v1/")
 
         return cls._instance
 
-    def save(self, key, value):
-        """Save a value to the config
 
-        Values that are saved are written to the config file.  
+    def save(self):
+        """Save the config to a file
+
         The default path for this file is `~/.refinebio.yaml`  
         but it can be set using the environment variable `CONFIG_FILE`.
         """
-        if not os.path.exists(self.config_file):
-            config = {}
-        else:
-            with open(self.config_file, "r") as config_file:
-                config = yaml.full_load(config_file) or {}
-
-        config[key] = value
-        setattr(self._instance, key, value)
+        config = {
+            "token": self.token,
+            "base_url": self.base_url
+        }
 
         with open(self.config_file, "w") as config_file:
             yaml.dump(config, config_file)

--- a/pyrefinebio/token.py
+++ b/pyrefinebio/token.py
@@ -108,8 +108,8 @@ class Token:
 
 
     @classmethod
-    def get_token(cls):
-        """Gets the token that's currently set to Config."""
+    def load_token(cls):
+        """Loads the token that's currently set to Config."""
         return Token(id=config.token)
 
 

--- a/pyrefinebio/token.py
+++ b/pyrefinebio/token.py
@@ -8,13 +8,15 @@ from pyrefinebio.config import Config
 from pyrefinebio.exceptions import NotFound, BadRequest
 
 
+config = Config()
+
 class Token:
-    """Handles the creation, activation, saving, and loading of api tokens.
+    """Handles the creation, activation, saving, and loading of refine.bio's api tokens.
 
     These tokens can be used in requests that provide urls to download computed files.
 
-    Please review refine.bio's [Terms of Use](https://www.refine.bio/terms) and [Privacy Policy](https://www.refine.bio/privacy)
-    before use of these tokens.
+    Please review refine.bio's [Terms of Use](https://www.refine.bio/terms) and 
+    [Privacy Policy](https://www.refine.bio/privacy) before use of these tokens.
 
     Create a new Token
 
@@ -33,7 +35,7 @@ class Token:
         >>> token = pyrefinebio.Token(email_address="foo@bar.com")
         >>> token.save_token()
 
-    Load the Token that is currently saved to the config file
+    Load the Token that is currently set to Config
 
         >>> import pyrefinebio
         >>> token = pyrefinebio.Token.load_token()
@@ -60,6 +62,12 @@ class Token:
 
     def agree_to_terms_and_conditions(self):
         """Activates a token.
+        
+        Tokens that are activated will be added to Config and can be used to make requests
+        until pyrefinebio is re-imported.
+
+        If you would like to continue using the same Token for other scripts that use pyrefinebio
+        save the Token to the Config file using save_token().
 
         Activating a token indicates agreement with refine.bio's
         [Terms of Use](https://www.refine.bio/terms) and
@@ -72,6 +80,8 @@ class Token:
                 "Token with id '" + str(self.id) + "' does not exist in RefineBio. " 
                 "Please create a new token."
             )
+        
+        config.token = self.id
 
 
     def save_token(self):
@@ -93,19 +103,15 @@ class Token:
                 "Please create a new token."
             )
 
-        config = Config()
-        config.save("token", self.id)
+        config.token = self.id
+        config.save()
 
 
     @classmethod
     def get_token(cls):
-        """gets the token that's currently saved to the config file.
-
-        The default config file is ~/.refinebio.yaml, but
-        you can use the environment variable `CONFIG_FILE` to change this path
-        """
-        config = Config()
+        """Gets the token that's currently set to Config."""
         return Token(id=config.token)
+
 
     def __str__(self):
         return str(self.id)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -132,15 +132,8 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
         self.assertTrue(ds.is_processing)
 
 
-    @patch("pyrefinebio.config.os.path.exists")
-    @patch("pyrefinebio.config.yaml.full_load")
-    @patch("pyrefinebio.config.open")
-    def test_dataset_process_bad_token(self, mock_open, mock_load, mock_exists):
-        Config._instance = None
-        os.environ["CONFIG_FILE"] = "./temp"
-        mock_open.return_value.__enter__.return_value = "file"
-        mock_load.return_value = {"token": "this-is-a-bad-token"}
-        mock_exists.return_value = True
+    def test_dataset_process_bad_token(self):
+        pyrefinebio.config.Config().token = "this-is-a-bad-token"
 
         data = {}
         exs = pyrefinebio.Experiment.search(num_downloadable_samples=1)
@@ -155,22 +148,13 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
         self.assertEqual(br.exception.base_message, "Bad Request: You must provide an active API token ID")
 
     
-    @patch("pyrefinebio.config.os.path.exists")
-    @patch("pyrefinebio.config.yaml.full_load")
-    @patch("pyrefinebio.config.open")
-    def test_dataset_process_no_email(self, mock_open, mock_load, mock_exists):
-        Config._instance = None
-        os.environ["CONFIG_FILE"] = "./temp"
-        mock_open.return_value.__enter__.return_value = "file"
-        mock_load.return_value = {"token": "42240c84-b3d9-4f41-8001-6f40abce9d7d"}
-        mock_exists.return_value = True
-
+    def test_dataset_process_no_email(self):
         try:
-            token = pyrefinebio.Token.get_token()
-            pyrefinebio.Token.agree_to_terms_and_conditions(token)
+            token = pyrefinebio.Token(id="42240c84-b3d9-4f41-8001-6f40abce9d7d")
+            token.agree_to_terms_and_conditions()
         except pyrefinebio.exceptions.NotFound:
-            token = pyrefinebio.Token.create_token("")
-            pyrefinebio.Token.agree_to_terms_and_conditions(token)
+            token = pyrefinebio.Token()
+            token.agree_to_terms_and_conditions()
 
         data = {}
         exs = pyrefinebio.Experiment.search(num_downloadable_samples=1)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -112,15 +112,10 @@ class TokenTests(unittest.TestCase, CustomAssertions):
         )
 
 
-    @patch("pyrefinebio.token.get_by_endpoint")
-    @patch("pyrefinebio.config.os.path.exists")
-    @patch("pyrefinebio.config.yaml.full_load")
-    @patch("pyrefinebio.config.open")
-    def test_token_get(self, mock_open, mock_load, mock_exists, mock_get):
-        os.environ["CONFIG_FILE"] = "./temp"
-        mock_open.return_value.__enter__.return_value = "file"
-        mock_load.return_value = {"token": "this-is-a-test-token"}
-        mock_exists.return_value = True
+    @patch("pyrefinebio.token.put_by_endpoint")
+    def test_token_get(self, mock_put):
+        mock_put.return_value = True
+        pyrefinebio.Token(id="this-is-a-test-token").agree_to_terms_and_conditions()
 
         token = pyrefinebio.Token.get_token()
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -63,7 +63,13 @@ class TokenTests(unittest.TestCase, CustomAssertions):
         token.save_token()
 
         mock_open.assert_called_with("test", "w")
-        mock_yaml.assert_called_with({"token": token.id}, "file")
+        mock_yaml.assert_called_with(
+            {
+                "token": token.id,
+                "base_url": "https://api.refine.bio/v1/"
+            },
+            "file"
+        )
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
@@ -90,7 +96,6 @@ class TokenTests(unittest.TestCase, CustomAssertions):
             "Token with id 'test' does not exist in RefineBio. " 
             "Please create a new token."
         )
-
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -113,11 +113,11 @@ class TokenTests(unittest.TestCase, CustomAssertions):
 
 
     @patch("pyrefinebio.token.put_by_endpoint")
-    def test_token_get(self, mock_put):
+    def test_token_load(self, mock_put):
         mock_put.return_value = True
         pyrefinebio.Token(id="this-is-a-test-token").agree_to_terms_and_conditions()
 
-        token = pyrefinebio.Token.get_token()
+        token = pyrefinebio.Token.load_token()
 
         self.assertEqual(token.id, "this-is-a-test-token")
 


### PR DESCRIPTION
## Related Issues

#30 
#8 

## Updates

- you can now add a token to Config and use it in requests without having to save it to a file
- the Config file isn't open and read every time config is saved - everything is just dumped to the file
- documentation updates to make Token and Config easier to understand

<details>
<summary>Config Doc Screenshot</summary>
<p>

![image](https://user-images.githubusercontent.com/52019096/106058772-b95f9080-60bf-11eb-9905-4cde0550ab0e.png)

</p>
</details>

