### PR TITLE
Update Errors

### DIFF
--- a/pyrefinebio/compendia.py
+++ b/pyrefinebio/compendia.py
@@ -101,7 +101,12 @@ class Compendium(Base):
             prompt (bool): if true, will prompt before downloading files bigger than 1GB
         """
         if not self.computed_file.download_url:
-            raise DownloadError("Compendia", "Download url not found - did you set up and activate a Token?")
+            raise DownloadError(
+                "Compendia",
+                "Download url not found - make sure you have set up and activated your Token. "
+                "You can create and activate a new token using pyrefinebio.Token. "
+                "See documentation for advanced usage: https://alexslemonade.github.io/refinebio-py/token.html"
+            )
 
         full_path = expand_path(path, "compendium-" + str(self.id) + ".zip")
 

--- a/pyrefinebio/computed_file.py
+++ b/pyrefinebio/computed_file.py
@@ -144,7 +144,12 @@ class ComputedFile(Base):
             prompt (bool): if true, will prompt before downloading files bigger than 1GB
         """
         if not self.download_url:
-            raise DownloadError("ComputedFile", "Download url not found - did you set up and activate a Token?")
+            raise DownloadError(
+                "ComputedFile",
+                "Download url not found - make sure you have set up and activated your Token. "
+                "You can create and activate a new token using pyrefinebio.Token. "
+                "See documentation for advanced usage: https://alexslemonade.github.io/refinebio-py/token.html"
+            )
 
         full_path = expand_path(path, "computedfile-" + str(self.id) + ".zip")
 

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -246,7 +246,16 @@ class Dataset(Base):
         download_url = self.download_url or self.get(self.id).download_url
 
         if not download_url:
-            raise DownloadError("dataset", "Download url not found - did you process the dataset?")
+            if self.check():
+                raise DownloadError(
+                    "Dataset",
+                    "Download url not found - did you set up and activate a Token?"
+                )
+            else:
+                raise DownloadError(
+                    "Dataset",
+                    "Download url not found - you must process the Dataset before downloading."
+                )
 
         full_path = expand_path(path, "dataset-" + str(self.id) + ".zip")
 

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -249,7 +249,9 @@ class Dataset(Base):
             if self.check():
                 raise DownloadError(
                     "Dataset",
-                    "Download url not found - did you set up and activate a Token?"
+                    "Download url not found - make sure you have set up and activated your Token. "
+                    "You can create and activate a new token using pyrefinebio.Token. "
+                    "See documentation for advanced usage: https://alexslemonade.github.io/refinebio-py/token.html"
                 )
             else:
                 raise DownloadError(

--- a/pyrefinebio/exceptions.py
+++ b/pyrefinebio/exceptions.py
@@ -1,10 +1,4 @@
-class Error(Exception):
-    def __init__(self, message=None):
-        self.message = message
-        super().__init__(self.message)
-
-
-class ServerError(Error):
+class ServerError(Exception):
     base_message = "The server encountered an issue"
     def __init__(self, message=None):
         if message:
@@ -12,7 +6,7 @@ class ServerError(Error):
         super().__init__(self.base_message)
 
 
-class BadRequest(Error):
+class BadRequest(Exception):
     base_message = "Bad Request"
     def __init__(self, message=None):
         if message:
@@ -20,25 +14,29 @@ class BadRequest(Error):
         super().__init__(self.base_message)
 
 
-class NotFound(Error):
+class NotFound(Exception):
     base_message = "The requested resource at {0} was not found"
     def __init__(self, url):
         super().__init__(self.base_message.format(url))
 
 
-class InvalidFilters(Error):
-    base_message = "You have provided invalid filters: {0}"
+class InvalidFilters(Exception):
+    base_message = (
+        "You have provided invalid filters: {0}\n"
+        "Check the documentation for a list of valid filters\n"
+        "https://alexslemonade.github.io/refinebio-py/"
+    )
     def __init__(self, invalid_filters):
         super().__init__(self.base_message.format(invalid_filters))
 
 
-class InvalidFilterType(Error):
+class InvalidFilterType(Exception):
     base_message = "You have provided invalid type for the filter, {0} - {1}"
     def __init__(self, filter, info):
         super().__init__(self.base_message.format(filter, info))
 
 
-class InvalidData(Error):
+class InvalidData(Exception):
     base_message = ""
     def __init__(self, message, details):
         self.base_message = message
@@ -47,7 +45,7 @@ class InvalidData(Error):
         super().__init__(self.base_message)
 
 
-class DownloadError(Error):
+class DownloadError(Exception):
     base_message = "Unable to download {0}"
     def __init__(self, type, extra_info=None):
         if extra_info:
@@ -55,7 +53,7 @@ class DownloadError(Error):
         super().__init__(self.base_message.format(type))
 
 
-class MultipleErrors(Error):
+class MultipleErrors(Exception):
     base_message = "Multiple errors have occurred:\n"
     def __init__(self, errors):
         for error in errors:
@@ -63,7 +61,7 @@ class MultipleErrors(Error):
         super().__init__(self.base_message)
 
 
-class MissingFile(Error):
+class MissingFile(Exception):
     base_message = "Missing file: {0}"
     def __init__(self, file_name, extra_info=None):
         if extra_info:

--- a/pyrefinebio/script.py
+++ b/pyrefinebio/script.py
@@ -127,7 +127,7 @@ def download_dataset(
             skip_quantile_normalization,
         )
     except DownloadError as e:
-        raise click.ClickException(e.message)
+        raise click.ClickException(str(e))
 
 
 @cli.command()
@@ -156,7 +156,7 @@ def download_compendium(organism, path, quant_sf_only=False):
     try:
         hlf.download_compendium(path, organism, quant_sf_only)
     except DownloadError as e:
-        raise click.ClickException(e.message)
+        raise click.ClickException(str(e))
 
 
 @cli.command()
@@ -180,4 +180,4 @@ def download_quandfile_compendium(organism, path):
     try:
         hlf.download_quandfile_compendium(path, organism)
     except DownloadError as e:
-        raise click.ClickException(e.message)
+        raise click.ClickException(str(e))

--- a/pyrefinebio/token.py
+++ b/pyrefinebio/token.py
@@ -1,8 +1,4 @@
-import logging
 import os
-from pathlib import Path
-
-import yaml
 
 from pyrefinebio.base import Base
 
@@ -77,7 +73,7 @@ class Token(Base):
         [Privacy Policy](https://www.refine.bio/privacy).
         """
         try:
-            put_by_endpoint("token/" + self.id, payload={"is_activated": True})
+            put_by_endpoint("token/" + str(self.id), payload={"is_activated": True})
         except NotFound:
             raise BadRequest(
                 "Token with id '" + str(self.id) + "' does not exist in refine.bio. " 
@@ -103,7 +99,7 @@ class Token(Base):
         except NotFound:
             raise BadRequest(
                 "Token with id '" + str(self.id) + "' does not exist in refine.bio. " 
-                "Please create a new token."
+                "Please create a new token using pyrefinebio.Token()."
             )
 
         config.token = self.id
@@ -114,7 +110,3 @@ class Token(Base):
     def load_token(cls):
         """Loads the token that's currently set to Config."""
         return Token(id=config.token)
-
-
-    def __str__(self):
-        return str(self.id)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -247,7 +247,7 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
         
         self.assertEqual(
             str(de.exception),
-            "Unable to download Dataset\nDownload url not found - did you process the dataset?"
+            "Unable to download Dataset\nDownload url not found - you must process the Dataset before downloading."
         )
     
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -246,8 +246,8 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
             ds.download("test")
         
         self.assertEqual(
-            de.exception.message,
-            "Unable to download dataset\nDownload url not found - did you process the dataset?"
+            str(de.exception),
+            "Unable to download Dataset\nDownload url not found - did you process the dataset?"
         )
     
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -94,7 +94,7 @@ class TokenTests(unittest.TestCase, CustomAssertions):
             br.exception.base_message,
             "Bad Request: "
             "Token with id 'test' does not exist in refine.bio. " 
-            "Please create a new token."
+            "Please create a new token using pyrefinebio.Token()."
         )
 
 


### PR DESCRIPTION
## Related Issues

#26 
See issue for more details.

## Changes

### Using invalid search filters

Added "Check the documentation for a list of valid filters"
Also added a link to the docs

### Using invalid types for search filters

We might be able to add helpful messages like "use `Organism.search()` to get a list of valid organisms" if they pass in an invalid organism as a filter.
It might be a lot of logic though.
Also, I'm not really sure which filters are even type checked. It all happens API side via Django magic.
for example: boolean filters are not type checked
https://api.refine.bio/v1/compendia/?quant_sf_only=bar works fine

@kurtwheeler it might be a good idea to chat about this

### Trying to download a Dataset with an Experiment that has no downloadable Samples

Adding the info that users can request/create issues for experiments that have no downloadable samples might have to be added API side.
There are multiple `invalid_data` exceptions returned by the API. We could parse the message client side to add the info, but I think it would be best to just add it API side.

### Trying to download a Dataset without a valid token

Added logic to change message depending on if the download url is missing because the Dataset wasn't processed vs token problems

### Trying to save a token with an invalid id

Updated message to include method to create a new token.
Also updated format of `refine.bio` everywhere - I think I actually did this in a previous PR

