### PR TITLE
remove OriginalFile download method

### DIFF
--- a/pyrefinebio/original_file.py
+++ b/pyrefinebio/original_file.py
@@ -113,15 +113,3 @@ class OriginalFile(Base):
 
         response = get_by_endpoint("original_files", params=kwargs)
         return create_paginated_list(cls, response)
-        
-
-    def download(self, path):
-        """Download an OriginalFile
-
-        Returns:
-            void
-
-        Parameters:
-            path (str): the path that then OriginalFile should be downloaded to
-        """
-        pass


### PR DESCRIPTION
## Related Issues

#33 

I added a download method for OriginalFile as a part of another PR for that issue, but it never got implemented.

Implementing `download` for OriginalFiles is out of scope for now.
Maybe if a lot of users request that feature in the future we can add it though.