### PR TITLE
Get missing data for objects fetched via list endpoints

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -206,7 +206,7 @@ that can print out information about all its classes/functions.
 
 The `help()` function is probably most useful in the REPL.
 
-Here's and example:
+Here's an example:
 
 .. code-block:: shell
 

--- a/pyrefinebio/base.py
+++ b/pyrefinebio/base.py
@@ -1,10 +1,15 @@
 from pprint import pformat
 
-class Base:
+class Base(object):
     """Base class that all pyrefinebio classes inherit from.
 
     Contains helpful methods that relate to all classes.
     """
+
+    def __init__(self, identifier=None):
+        self._identifier = identifier
+        self._fetched = False
+
 
     def __str__(self):
         return pformat(self._to_dict())
@@ -16,8 +21,20 @@ class Base:
         for key, value in self.__dict__.items():
             if isinstance(value, Base):
                 expanded[key] = value._to_dict()
-            else:
+            elif not key.startswith("_"):
                 expanded[key] = value
 
         return expanded
 
+
+    def __getattribute__(self, attr):
+        if not attr.startswith("_") and object.__getattribute__(self, attr) is None and not self._fetched:
+            # if somehow the identifier isn't set we can't fetch
+            # this will only happen with Datasets which can be created by non-api calls
+            if self._identifier:
+                result = self.get(self._identifier)
+                for key, value in result.__dict__.items():
+                    setattr(self, key, value)
+                self._fetched = True
+
+        return object.__getattribute__(self, attr)

--- a/pyrefinebio/compendia.py
+++ b/pyrefinebio/compendia.py
@@ -32,6 +32,8 @@ class Compendium(Base):
         compendium_version=None,
         computed_file=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.primary_organism_name = primary_organism_name
         self.organism_names = organism_names

--- a/pyrefinebio/computational_result.py
+++ b/pyrefinebio/computational_result.py
@@ -38,6 +38,8 @@ class ComputationalResult(Base):
         created_at=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.commands = commands
         self.processor = prb_processor.Processor(**(processor)) if processor else None

--- a/pyrefinebio/computed_file.py
+++ b/pyrefinebio/computed_file.py
@@ -48,6 +48,8 @@ class ComputedFile(Base):
         last_modified=None,
         result=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.filename = filename
         self.samples = [prb_sample.Sample(**sample) for sample in samples] if samples else []

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -76,6 +76,8 @@ class Dataset(Base):
         svd_algorithm=None,
         download_url=None
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.data = data 
         self.aggregate_by = aggregate_by

--- a/pyrefinebio/experiment.py
+++ b/pyrefinebio/experiment.py
@@ -54,6 +54,8 @@ class Experiment(Base):
         num_processed_samples=None,
         num_downloadable_samples=None,
     ):
+        super().__init__(identifier=accession_code)
+
         self.id = id
         self.title = title
         self.description = description

--- a/pyrefinebio/job.py
+++ b/pyrefinebio/job.py
@@ -37,6 +37,8 @@ class DownloaderJob(Base):
         created_at=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.downloader_task = downloader_task
         self.num_retries = num_retries
@@ -154,6 +156,8 @@ class ProcessorJob(Base):
         created_at=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.pipeline_applied = pipeline_applied
         self.num_retries = num_retries
@@ -266,6 +270,8 @@ class SurveyJob(Base):
         created_at=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.source_type = source_type
         self.success = success

--- a/pyrefinebio/organism.py
+++ b/pyrefinebio/organism.py
@@ -26,6 +26,8 @@ class Organism(Base):
         has_compendia=None,
         has_quantfile_compendia=None
     ):
+        super().__init__(identifier=name)
+
         self.name = name
         self.taxonomy_id = taxonomy_id
         self.has_compendia = has_compendia

--- a/pyrefinebio/original_file.py
+++ b/pyrefinebio/original_file.py
@@ -39,6 +39,8 @@ class OriginalFile(Base):
         created_at=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.filename = filename
         self.size_in_bytes = size_in_bytes

--- a/pyrefinebio/processor.py
+++ b/pyrefinebio/processor.py
@@ -26,6 +26,8 @@ class Processor(Base):
         docker_image=None,
         environment=None
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.name = name
         self.version = version

--- a/pyrefinebio/qn_target.py
+++ b/pyrefinebio/qn_target.py
@@ -35,6 +35,8 @@ class QNTarget(Base):
         last_modified=None,
         result=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.filename = filename
         self.size_in_bytes = size_in_bytes

--- a/pyrefinebio/sample.py
+++ b/pyrefinebio/sample.py
@@ -61,6 +61,8 @@ class Sample(Base):
         experiment_accession_codes=None,
         experiments=None,
     ):
+        super().__init__(identifier=accession_code)
+
         self.id = id
         self.title = title
         self.accession_code = accession_code
@@ -108,7 +110,7 @@ class Sample(Base):
     def experiments(self):
         if not self._experiments:
             self._experiments = prb_experiment.Experiment.search(
-                accession_codes=self.experiment_accession_codes
+                accession_code=self.experiment_accession_codes
             )
 
         return self._experiments

--- a/pyrefinebio/transcriptome_index.py
+++ b/pyrefinebio/transcriptome_index.py
@@ -32,6 +32,8 @@ class TranscriptomeIndex(Base):
         result_id=None,
         last_modified=None,
     ):
+        super().__init__(identifier=id)
+
         self.id = id
         self.assembly_name = assembly_name
         self.organism_name = organism_name

--- a/tests/test_compendia.py
+++ b/tests/test_compendia.py
@@ -1,5 +1,7 @@
 import unittest
 import pyrefinebio
+import os
+
 from unittest.mock import Mock, patch
 
 from tests.custom_assertions import CustomAssertions
@@ -141,13 +143,13 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
 
         mock_download.assert_called_with(
             "test_download_url",
-            "test-path",
+            os.path.abspath("test-path"),
             True
         )
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_compendium_download(self, mock_request):
+    def test_compendium_download_no_url(self, mock_request):
         result = pyrefinebio.Compendium.get(2) # 2 has no download_url
 
         with self.assertRaises(pyrefinebio.exceptions.DownloadError) as de:

--- a/tests/test_compendia.py
+++ b/tests/test_compendia.py
@@ -73,10 +73,10 @@ search_2 = {
 
 def mock_request(method, url, **kwargs):
 
-    if url == "https://api.refine.bio/v1/compendia/1/":
+    if url == "https://api.refine.bio/v1/compendia/69/":
         return MockResponse(compendium_object_1, url)
 
-    if url == "https://api.refine.bio/v1/compendia/2/":
+    if url == "https://api.refine.bio/v1/compendia/42/":
         return MockResponse(compendium_object_2, url)
 
     if url == "https://api.refine.bio/v1/compendia/0/":
@@ -95,7 +95,7 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_get(self, mock_request):
-        result = pyrefinebio.Compendium.get(1)
+        result = pyrefinebio.Compendium.get(69)
         self.assertObject(result, compendium_object_1)
 
 
@@ -118,8 +118,6 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
         self.assertObject(results[0], compendium_object_1)
         self.assertObject(results[1], compendium_object_2)
 
-        self.assertEqual(len(mock_request.call_args_list), 2)
-
 
     def test_compendium_search_with_filters(self):
         filtered_results = pyrefinebio.Compendium.search(primary_organism__name="ACTINIDIA_CHINENSIS")
@@ -137,7 +135,7 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.compendia.download_file") 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_download(self, mock_request, mock_download):
-        result = pyrefinebio.Compendium.get(1)
+        result = pyrefinebio.Compendium.get(69)
 
         result.download("test-path")
 
@@ -150,7 +148,9 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_download_no_url(self, mock_request):
-        result = pyrefinebio.Compendium.get(2) # 2 has no download_url
+        result = pyrefinebio.Compendium.get(42) # 2 has no download_url
+
+        result.computed_file._fetched = True # set fetched to true so that a request isn't made to /computed_files
 
         with self.assertRaises(pyrefinebio.exceptions.DownloadError) as de:
             result.download("test-path")

--- a/tests/test_compendia.py
+++ b/tests/test_compendia.py
@@ -148,7 +148,7 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_download_no_url(self, mock_request):
-        result = pyrefinebio.Compendium.get(42) # 2 has no download_url
+        result = pyrefinebio.Compendium.get(42) # 42 has no download_url
 
         result.computed_file._fetched = True # set fetched to true so that a request isn't made to /computed_files
 

--- a/tests/test_compendia.py
+++ b/tests/test_compendia.py
@@ -9,7 +9,7 @@ from tests.mocks import MockResponse
 
 
 compendium_object_1 = {
-    "id": 69,
+    "id": 1,
     "primary_organism_name": "HUMAN",
     "organism_names": [
         "HUMAN",
@@ -73,7 +73,7 @@ search_2 = {
 
 def mock_request(method, url, **kwargs):
 
-    if url == "https://api.refine.bio/v1/compendia/69/":
+    if url == "https://api.refine.bio/v1/compendia/1/":
         return MockResponse(compendium_object_1, url)
 
     if url == "https://api.refine.bio/v1/compendia/42/":
@@ -95,7 +95,7 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_get(self, mock_request):
-        result = pyrefinebio.Compendium.get(69)
+        result = pyrefinebio.Compendium.get(1)
         self.assertObject(result, compendium_object_1)
 
 
@@ -135,7 +135,7 @@ class CompendiumTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.compendia.download_file") 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_compendium_download(self, mock_request, mock_download):
-        result = pyrefinebio.Compendium.get(69)
+        result = pyrefinebio.Compendium.get(1)
 
         result.download("test-path")
 

--- a/tests/test_computational_result.py
+++ b/tests/test_computational_result.py
@@ -135,7 +135,7 @@ def mock_request(method, url, **kwargs):
         return MockResponse(computational_result_1, url)
 
     if url == "https://api.refine.bio/v1/computational_results/2/":
-        return MockResponse(computational_result_1, url)
+        return MockResponse(computational_result_2, url)
 
     if url == "https://api.refine.bio/v1/computational_results/0/":
         return MockResponse(None, url, status=404)

--- a/tests/test_computational_result.py
+++ b/tests/test_computational_result.py
@@ -6,7 +6,7 @@ from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 
 computational_result_1 = {
-    "id": 0,
+    "id": 1,
     "commands": [
         "test1",
         "test2"
@@ -61,7 +61,7 @@ computational_result_1 = {
 }
 
 computational_result_2 = {
-    "id": 0,
+    "id": 2,
     "commands": [
         "test1",
         "test2"
@@ -134,6 +134,9 @@ def mock_request(method, url, **kwargs):
     if url == "https://api.refine.bio/v1/computational_results/1/":
         return MockResponse(computational_result_1, url)
 
+    if url == "https://api.refine.bio/v1/computational_results/2/":
+        return MockResponse(computational_result_1, url)
+
     if url == "https://api.refine.bio/v1/computational_results/0/":
         return MockResponse(None, url, status=404)
 
@@ -168,14 +171,10 @@ class ComputationalResultTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_computational_result_search_no_filters(self, mock_request):
-        result = pyrefinebio.ComputationalResult.search()
+        results = pyrefinebio.ComputationalResult.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], computational_result_1)
-        self.assertObject(result_list[1], computational_result_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], computational_result_1)
+        self.assertObject(results[1], computational_result_2)
 
 
     def test_computational_result_search_with_filters(self):

--- a/tests/test_computed_file.py
+++ b/tests/test_computed_file.py
@@ -254,7 +254,7 @@ class ComputedFileTests(unittest.TestCase, CustomAssertions):
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_computed_file_download(self, mock_request):
+    def test_computed_file_download_no_url(self, mock_request):
         result = pyrefinebio.ComputedFile.get(2) # 2 has no download_url
 
         with self.assertRaises(pyrefinebio.exceptions.DownloadError) as de:

--- a/tests/test_computed_file.py
+++ b/tests/test_computed_file.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 import pyrefinebio
 from unittest.mock import Mock, patch
 
@@ -7,7 +8,7 @@ from tests.mocks import MockResponse
 
 
 computed_file_1 = {
-    "id": 5836309,
+    "id": 1,
     "filename": "salmontools-result.tar.gz",
     "samples": [
         {
@@ -84,7 +85,7 @@ computed_file_1 = {
 }
 
 computed_file_2 = {
-    "id": 5836309,
+    "id": 2,
     "filename": "salmontools-result.tar.gz",
     "samples": [
         {
@@ -159,6 +160,56 @@ computed_file_2 = {
     }
 }
 
+result = {
+    "id": 2784485,
+    "commands": [
+        "salmontools extract-unmapped -u /home/user/data_store/processor_job_29708301/SRR067392_output/aux_info/unmapped_names.txt -o /home/user/data_store/processor_job_29708301/salmontools/unmapped_by_salmon -r /home/user/data_store/processor_job_29708301/SRR067392.sra"
+    ],
+    "processor": {
+        "id": 607,
+        "name": "Salmontools",
+        "version": "v1.39.5",
+        "docker_image": "dr_salmon",
+        "environment": {
+            "os_pkg": {
+                "g++": "4:5.3.1-1ubuntu1",
+                "cmake": "3.5.1-1ubuntu3",
+                "python3": "3.5.1-3",
+                "python3-pip": "8.1.1-2ubuntu0.4"
+            },
+            "python": {
+                "Django": "2.2.13",
+                "data-refinery-common": "1.39.5"
+            },
+            "cmd_line": {
+                "salmontools --version": "Salmon Tools 0.1.0"
+            },
+            "os_distribution": "Ubuntu 16.04.6 LTS"
+        }
+    },
+    "is_ccdl": True,
+    "annotations": [],
+    "files": [
+        {
+            "id": 5836309,
+            "filename": "salmontools-result.tar.gz",
+            "size_in_bytes": 191,
+            "is_smashable": False,
+            "is_qc": True,
+            "sha1": "77ea7dd477fa9a9ec5f33bc91f46c0e224edeb92",
+            "s3_bucket": "data-refinery-s3-circleci-prod",
+            "s3_key": "gqo8hxhqm3tcz4c2x9sthhw5_salmontools-result.tar.gz",
+            "created_at": "2020-10-01T20:23:41.661425Z",
+            "last_modified": "2020-10-01T20:23:42.378884Z"
+        }
+    ],
+    "organism_index": None,
+    "time_start": "2020-10-01T20:23:06.885498Z",
+    "time_end": "2020-10-01T20:23:41.030134Z",
+    "created_at": "2020-10-01T20:23:41.655614Z",
+    "last_modified": "2020-10-01T20:23:41.655614Z"
+}
+
 search_1 = {
     "count": 2,
     "next": "search_2",
@@ -193,6 +244,9 @@ def mock_request(method, url, **kwargs):
     if url == "search_2":
         return MockResponse(search_2, url)
 
+    if url == "https://api.refine.bio/v1/computational_results/2784485/":
+        return MockResponse(result, url)
+
 class ComputedFileTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
@@ -215,14 +269,10 @@ class ComputedFileTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_computed_file_search_no_filters(self, mock_request):
-        result = pyrefinebio.ComputedFile.search()
+        results = pyrefinebio.ComputedFile.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], computed_file_1)
-        self.assertObject(result_list[1], computed_file_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], computed_file_1)
+        self.assertObject(results[1], computed_file_2)
 
 
     def test_computed_file_search_with_filters(self):
@@ -248,7 +298,7 @@ class ComputedFileTests(unittest.TestCase, CustomAssertions):
 
         mock_download.assert_called_with(
             "test_download_url",
-            "test-path",
+            os.path.abspath("test-path"),
             True
         )
 
@@ -270,3 +320,25 @@ class ComputedFileTests(unittest.TestCase, CustomAssertions):
         cf.extract()
 
         mock_unpack.assert_called_with("foo")
+
+    
+    def test_computed_file_samples_are_fully_populated(self):
+        # ComputedFile.Sample looks like this when retrieved from the API
+        # We should make sure that the other sample properties are populated properly
+        # {
+        #     "accession_code": "SRR067392",
+        #     "platform_name": "Illumina Genome Analyzer II",
+        #     "pretty_platform": "Illumina Genome Analyzer II (IlluminaGenomeAnalyzerII)",
+        #     "technology": "RNA-SEQ",
+        #     "is_processed": True
+        # }
+
+        cfs = pyrefinebio.ComputedFile.search()
+        cf = next(cf for cf in cfs if cf.samples)
+
+        self.assertIsNotNone(cf.samples[0].experiment_accession_codes)
+        self.assertIsNotNone(cf.samples[0].source_database)
+        self.assertIsNotNone(cf.samples[0].organism)
+        self.assertIsNotNone(cf.samples[0].platform_accession_code)
+        self.assertIsNotNone(cf.samples[0].pretty_platform)
+        self.assertIsNotNone(cf.samples[0].manufacturer)

--- a/tests/test_downloader_job.py
+++ b/tests/test_downloader_job.py
@@ -66,6 +66,9 @@ def mock_request(method, url, **kwargs):
     if url == "https://api.refine.bio/v1/jobs/downloader/1/":
         return MockResponse(job_1, url)
 
+    if url == "https://api.refine.bio/v1/jobs/downloader/2/":
+        return MockResponse(job_2, url)
+
     if url == "https://api.refine.bio/v1/jobs/downloader/0/":
         return MockResponse(None, url, status=404)
 
@@ -100,14 +103,10 @@ class DownloaderJobTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_downloader_job_search_no_filters(self, mock_request):
-        result = pyrefinebio.DownloaderJob.search()
+        results = pyrefinebio.DownloaderJob.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], job_1)
-        self.assertObject(result_list[1], job_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], job_1)
+        self.assertObject(results[1], job_2)
 
 
     def test_downloader_job_search_with_filters(self):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -53,7 +53,7 @@ experiment = {
 }
 
 experiment_search_result_1 = {
-    "id": 69,
+    "id": 42,
     "title": "test title 1",
     "publication_title": "test title 1",
     "description": "test description 1",
@@ -87,7 +87,7 @@ experiment_search_result_1 = {
 }
 
 experiment_search_result_2 = {
-    "id": 42,
+    "id": 43,
     "title": "test title 2",
     "publication_title": "test title 2",
     "description": "test description 2",

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -176,14 +176,10 @@ class ExperimentTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_experiments_search_no_filters(self, mock_request):
-        result = pyrefinebio.Experiment.search()
+        results = pyrefinebio.Experiment.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], experiment_search_result_1)
-        self.assertObject(result_list[1], experiment_search_result_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], experiment_search_result_1)
+        self.assertObject(results[1], experiment_search_result_2)
 
 
     def test_experiments_search_with_filters(self):

--- a/tests/test_high_level_functions.py
+++ b/tests/test_high_level_functions.py
@@ -184,9 +184,10 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
             pyrefinebio.download_compendium("test", "this-will-have-no-results")
 
 
+    @patch("pyrefinebio.computed_file.get_by_endpoint")
     @patch("pyrefinebio.compendia.get_by_endpoint")
-    def test_download_compendium_no_token(self, mock_get):
-        mock_get.return_value = MockResponse(
+    def test_download_compendium_no_token(self, mock_compendia_get, mock_computed_file_get):
+        mock_compendia_get.return_value = MockResponse(
             {
                 "count": 1,
                 "next": None,
@@ -198,6 +199,13 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
                         }
                     }
                 ]
+            },
+            "url"
+        )
+
+        mock_computed_file_get.return_value = MockResponse(
+            {
+                "download_url": None
             },
             "url"
         )

--- a/tests/test_organism.py
+++ b/tests/test_organism.py
@@ -74,14 +74,10 @@ class OrganismTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_organism_search_no_filters(self, mock_request):
-        result = pyrefinebio.Organism.search()
+        results = pyrefinebio.Organism.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], gorilla)
-        self.assertObject(result_list[1], mouse)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], gorilla)
+        self.assertObject(results[1], mouse)
 
     
     def test_organism_search_with_filters(self):

--- a/tests/test_original_file.py
+++ b/tests/test_original_file.py
@@ -5,6 +5,47 @@ from unittest.mock import Mock, patch
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 
+processor_job = {
+    "id": 29708302,
+    "pipeline_applied": "SALMON",
+    "num_retries": 0,
+    "retried": False,
+    "worker_id": "i-0ea363205be30776f",
+    "ram_amount": 12288,
+    "volume_index": "i-0ea363205be30776f",
+    "worker_version": "v1.39.5",
+    "failure_reason": None,
+    "nomad_job_id": "SALMON_i-0ea363205be30776f_12288/dispatch-1601583545-daff9ed4",
+    "success": True,
+    "original_files": [
+        2925811
+    ],
+    "datasets": [],
+    "start_time": "2020-10-01T20:20:04.109061Z",
+    "end_time": "2020-10-01T20:23:43.507988Z",
+    "created_at": "2020-10-01T20:19:05.841594Z",
+    "last_modified": "2020-10-01T20:23:43.508066Z"
+}
+
+downloader_job = {
+    "id": 7381811,
+    "downloader_task": "SRA",
+    "num_retries": 0,
+    "retried": False,
+    "was_recreated": False,
+    "worker_id": "i-0ea363205be30776f",
+    "worker_version": "v1.39.5",
+    "nomad_job_id": "DOWNLOADER_i-0ea363205be30776f_4096/dispatch-1601583299-b70b4a3f",
+    "failure_reason": None,
+    "success": True,
+    "original_files": [
+        2925811
+    ],
+    "start_time": "2020-10-01T20:18:23.079796Z",
+    "end_time": "2020-10-01T20:19:05.873400Z",
+    "created_at": "2020-10-01T20:14:59.668642Z",
+    "last_modified": "2020-10-01T20:19:05.873426Z"
+}
 
 og_file_1 = {
     "id": 1,
@@ -21,67 +62,10 @@ og_file_1 = {
         }
     ],
     "processor_jobs": [
-        {
-            "id": 29708302,
-            "pipeline_applied": "SALMON",
-            "num_retries": 0,
-            "retried": False,
-            "worker_id": "i-0ea363205be30776f",
-            "ram_amount": 12288,
-            "volume_index": "i-0ea363205be30776f",
-            "worker_version": "v1.39.5",
-            "failure_reason": None,
-            "nomad_job_id": "SALMON_i-0ea363205be30776f_12288/dispatch-1601583545-daff9ed4",
-            "success": True,
-            "original_files": [
-                2925811
-            ],
-            "datasets": [],
-            "start_time": "2020-10-01T20:20:04.109061Z",
-            "end_time": "2020-10-01T20:23:43.507988Z",
-            "created_at": "2020-10-01T20:19:05.841594Z",
-            "last_modified": "2020-10-01T20:23:43.508066Z"
-        }
+        processor_job
     ],
     "downloader_jobs": [
-        {
-            "id": 7381811,
-            "downloader_task": "SRA",
-            "num_retries": 0,
-            "retried": False,
-            "was_recreated": False,
-            "worker_id": "i-0ea363205be30776f",
-            "worker_version": "v1.39.5",
-            "nomad_job_id": "DOWNLOADER_i-0ea363205be30776f_4096/dispatch-1601583299-b70b4a3f",
-            "failure_reason": None,
-            "success": True,
-            "original_files": [
-                2925811
-            ],
-            "start_time": "2020-10-01T20:18:23.079796Z",
-            "end_time": "2020-10-01T20:19:05.873400Z",
-            "created_at": "2020-10-01T20:14:59.668642Z",
-            "last_modified": "2020-10-01T20:19:05.873426Z"
-        },
-        {
-            "id": 7381790,
-            "downloader_task": "SRA",
-            "num_retries": -1,
-            "retried": True,
-            "was_recreated": False,
-            "worker_id": "i-0ea363205be30776f",
-            "worker_version": "v1.39.5",
-            "nomad_job_id": "DOWNLOADER_i-0ea363205be30776f_1024/dispatch-1601583197-afd6e327",
-            "failure_reason": None,
-            "success": False,
-            "original_files": [
-                2925811
-            ],
-            "start_time": "2020-10-01T20:13:28.201378Z",
-            "end_time": None,
-            "created_at": "2020-10-01T20:13:07.850264Z",
-            "last_modified": "2020-10-01T20:14:59.693663Z"
-        }
+        downloader_job
     ],
     "source_url": "anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/SRR/SRR067/SRR067396/SRR067396.sra",
     "source_filename": "SRR067396.sra",
@@ -93,23 +77,25 @@ og_file_1 = {
 }
 
 og_file_list_1 = {
-    "id": 3,
-    "filename": "GSM2351172_A52084400939855091415421246947329.CEL",
+    "id": 1,
+    "filename": "SRR067396.sra",
+    "size_in_bytes": 1004703052,
+    "sha1": "cdef439e998b12e5f58a89b92f5a96d01aecbe75",
     "samples": [
         123456
     ],
-    "size_in_bytes": 69357911,
-    "sha1": "9a7068160ae899de6bb245f5e35982a4810cb36e",
     "processor_jobs": [
-        123456
+        29708302
     ],
-    "downloader_jobs": [],
-    "source_url": "ftp://ftp.ncbi.nlm.nih.gov/geo/samples/GSM2351nnn/GSM2351172/suppl/GSM2351172_A52084400939855091415421246947329.CEL.gz",
+    "downloader_jobs": [
+        7381811
+    ],
+    "source_url": "anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/SRR/SRR067/SRR067396/SRR067396.sra",
+    "source_filename": "SRR067396.sra",
     "is_archive": False,
-    "source_filename": "GSM2351172_A52084400939855091415421246947329.CEL.gz",
     "has_raw": True,
-    "created_at": "2020-10-13T23:03:56.233937Z",
-    "last_modified": "2020-10-13T23:03:56.233937Z"
+    "created_at": "2020-10-01T20:13:03.302659Z",
+    "last_modified": "2020-10-01T20:23:43.278755Z"
 }
 
 og_file_list_2 = {
@@ -164,6 +150,12 @@ def mock_request(method, url, **kwargs):
     if url == "https://api.refine.bio/v1/original_files/500/":
         return MockResponse(None, url, status=500)
 
+    if url == "https://api.refine.bio/v1/jobs/processor/29708302/":
+        return MockResponse(processor_job, url)
+
+    if url == "https://api.refine.bio/v1/jobs/downloader/7381811/":
+        return MockResponse(downloader_job, url)
+
     if url == "https://api.refine.bio/v1/original_files/":
         return MockResponse(search_1, "search_2")
 
@@ -192,14 +184,18 @@ class OriginalFileTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_original_file_search_no_filters(self, mock_request):
-        result = pyrefinebio.OriginalFile.search()
+        results = pyrefinebio.OriginalFile.search()
 
-        result_list = list(result)
+        self.assertObject(results[0], og_file_list_1)
+        self.assertObject(results[1], og_file_list_2)
 
-        self.assertObject(result_list[0], og_file_list_1)
-        self.assertObject(result_list[1], og_file_list_2)
 
-        self.assertEqual(len(mock_request.call_args_list), 2)
+    @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
+    def test_original_file_search_fully_populated(self, mock_request):
+        # for some reason /original_files search endpoint doesn't return is_downloaded
+        # make sure this property is populated correctly
+        result = pyrefinebio.OriginalFile.search()[0]
+        self.assertIsNotNone(result.is_downloaded)
 
 
     def test_original_file_search_with_filters(self):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -104,11 +104,7 @@ class ProcessorTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_processor_search_no_filters(self, mock_request):
-        result = pyrefinebio.Processor.search()
+        results = pyrefinebio.Processor.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], processor_1)
-        self.assertObject(result_list[1], processor_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], processor_1)
+        self.assertObject(results[1], processor_2)

--- a/tests/test_processor_job.py
+++ b/tests/test_processor_job.py
@@ -72,6 +72,9 @@ def mock_request(method, url, **kwargs):
     if url == "https://api.refine.bio/v1/jobs/processor/1/":
         return MockResponse(job_1, url)
 
+    if url == "https://api.refine.bio/v1/jobs/processor/2/":
+        return MockResponse(job_2, url)
+
     if url == "https://api.refine.bio/v1/jobs/processor/0/":
         return MockResponse(None, url, status=404)
 
@@ -106,14 +109,10 @@ class ProcessorJobTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
     def test_processor_job_search_no_filters(self, mock_request):
-        result = pyrefinebio.ProcessorJob.search()
+        results = pyrefinebio.ProcessorJob.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], job_1)
-        self.assertObject(result_list[1], job_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], job_1)
+        self.assertObject(results[1], job_2)
 
 
     def test_processor_job_search_with_filters(self):

--- a/tests/test_survey_job.py
+++ b/tests/test_survey_job.py
@@ -7,7 +7,7 @@ from tests.mocks import MockResponse
 
 
 job_1 = {
-    "id": 214443,
+    "id": 1,
     "source_type": "GEO",
     "success": True,
     "start_time": "2020-10-13T14:38:02.287672Z",
@@ -17,7 +17,7 @@ job_1 = {
 }
 
 job_2 = {
-    "id": 214440,
+    "id": 2,
     "source_type": "SRA",
     "success": False,
     "start_time": None,
@@ -45,6 +45,9 @@ def mock_request(method, url, **kwargs):
     if url == "https://api.refine.bio/v1/jobs/survey/1/":
         return MockResponse(job_1, url)
 
+    if url == "https://api.refine.bio/v1/jobs/survey/2/":
+        return MockResponse(job_2, url)
+
     if url == "https://api.refine.bio/v1/jobs/survey/0/":
         return MockResponse(None, url, status=404)
 
@@ -60,36 +63,32 @@ def mock_request(method, url, **kwargs):
 class SurveyJobTests(unittest.TestCase, CustomAssertions):
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_downloader_job_get(self, mock_request):
+    def test_survey_job_get(self, mock_request):
         result = pyrefinebio.SurveyJob.get(1)
         self.assertObject(result, job_1)
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_downloader_job_500(self, mock_request):
+    def test_survey_job_500(self, mock_request):
         with self.assertRaises(pyrefinebio.exceptions.ServerError):
             pyrefinebio.SurveyJob.get(500)
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_downloader_job_get_404(self, mock_request):
+    def test_survey_job_get_404(self, mock_request):
         with self.assertRaises(pyrefinebio.exceptions.NotFound):
             pyrefinebio.SurveyJob.get(0)
 
 
     @patch("pyrefinebio.http.requests.request", side_effect=mock_request)
-    def test_downloader_job_search_no_filters(self, mock_request):
-        result = pyrefinebio.SurveyJob.search()
+    def test_survey_job_search_no_filters(self, mock_request):
+        results = pyrefinebio.SurveyJob.search()
 
-        result_list = list(result)
-
-        self.assertObject(result_list[0], job_1)
-        self.assertObject(result_list[1], job_2)
-
-        self.assertEqual(len(mock_request.call_args_list), 2)
+        self.assertObject(results[0], job_1)
+        self.assertObject(results[1], job_2)
 
 
-    def test_downloader_job_search_with_filters(self):
+    def test_survey_job_search_with_filters(self):
         filtered_results = pyrefinebio.SurveyJob.search(id=214436, source_type="GEO", success=False)
 
         for result in filtered_results:
@@ -98,6 +97,6 @@ class SurveyJobTests(unittest.TestCase, CustomAssertions):
             self.assertFalse(result.success)
 
 
-    def test_computed_job_search_with_invalid_filters(self):
+    def test_survey_job_search_with_invalid_filters(self):
         with self.assertRaises(pyrefinebio.exceptions.InvalidFilters):
-            pyrefinebio.DownloaderJob.search(foo="bar")
+            pyrefinebio.SurveyJob.search(foo="bar")

--- a/tests/test_transcriptome_index.py
+++ b/tests/test_transcriptome_index.py
@@ -91,7 +91,6 @@ class TranscriptomeIndexTests(unittest.TestCase, CustomAssertions):
         self.assertObject(results[0], index_1)
         self.assertObject(results[1], index_2)
 
-        self.assertEqual(len(mock_request.call_args_list), 2)
 
     def test_transcriptome_index_search_with_filters(self):
         filtered_results = pyrefinebio.TranscriptomeIndex.search(


### PR DESCRIPTION
## Related Issue

#46 

## Changes

I decided to override `__getattribute__` in the base class to solve this problem.

This is my attempt to try to explain the logic I added to `__getattribute__` in writing:

- if we try to get an attribute like `sample.foo` check if `sample.foo` is None
- if it is None, check if that object has been fetched before
- if it has been fully fetched before then that attribute should be None and we can return
- if not it could be an attribute that wasn't populated from the original endpoint that returned it
- so, use the `get` method for that Object to fully populate the object then return `sample.foo`

Hopefully that all makes sense!