### PR TITLE
Rename the BASE_URL env var to REFINEBIO_BASE_URL 

### DIFF
--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -8,7 +8,7 @@ class Config:
     """Config for pyrefinebio.
 
     Config values can be set by environment variables or in the Config file.
-    
+
     The Config file's default location is `~/.refinebio.yaml`, but this location
     can be set by using the environment variable `CONFIG_FILE`
 
@@ -19,21 +19,21 @@ class Config:
 
             environment variable: `REFINEBIO_TOKEN`
 
-        base_url: 
-            The base url for the refine.bio api that should be used 
+        base_url:
+            The base url for the refine.bio api that should be used
             when making requests. The default is `https://api.refine.bio/v1/`
 
-            environment variable: `BASE_URL`
-    
+            environment variable: `REFINEBIO_BASE_URL`
+
     These config values can be modified directly in code, but it recommended that you
-    set them by using environment variables, by modifying them in Config file, or by 
+    set them by using environment variables, by modifying them in Config file, or by
     using other class methods provided - like `pyrefinebio.Token` for example.
 
     example Config file:
 
     .. code-block:: shell
 
-        token: foo-bar-baz 
+        token: foo-bar-baz
         base_url: https://api.refine.bio/v1/
     """
 
@@ -44,16 +44,14 @@ class Config:
 
         Config values are loaded from environment variables first, then the config file,
         then they are set to defaults.
-        
+
         returns:
             Config
         """
         if not cls._instance:
             cls._instance = super(Config, cls).__new__(cls)
 
-            cls.config_file = (
-                os.getenv("CONFIG_FILE") or str(Path.home()) + "/.refinebio.yaml"
-            )
+            cls.config_file = os.getenv("CONFIG_FILE") or str(Path.home()) + "/.refinebio.yaml"
 
             config = {}
 
@@ -62,21 +60,19 @@ class Config:
                     config = yaml.full_load(config_file) or {}
 
             cls.token = os.getenv("REFINEBIO_TOKEN") or config.get("token", "")
-            cls.base_url = os.getenv("BASE_URL") or config.get("base_url", "https://api.refine.bio/v1/")
+            cls.base_url = os.getenv("REFINEBIO_BASE_URL") or config.get(
+                "base_url", "https://api.refine.bio/v1/"
+            )
 
         return cls._instance
-
 
     def save(self):
         """Save the config to a file
 
-        The default path for this file is `~/.refinebio.yaml`  
+        The default path for this file is `~/.refinebio.yaml`
         but it can be set using the environment variable `CONFIG_FILE`.
         """
-        config = {
-            "token": self.token,
-            "base_url": self.base_url
-        }
+        config = {"token": self.token, "base_url": self.base_url}
 
         with open(self.config_file, "w") as config_file:
             yaml.dump(config, config_file)

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -10,7 +10,7 @@ class Config:
     Config values can be set by environment variables or in the Config file.
 
     The Config file's default location is `~/.refinebio.yaml`, but this location
-    can be set by using the environment variable `CONFIG_FILE`
+    can be set by using the environment variable `REFINEBIO_CONFIG_FILE`
 
     pyrefinebio's configurable values are:
 
@@ -51,7 +51,9 @@ class Config:
         if not cls._instance:
             cls._instance = super(Config, cls).__new__(cls)
 
-            cls.config_file = os.getenv("CONFIG_FILE") or str(Path.home()) + "/.refinebio.yaml"
+            cls.config_file = (
+                os.getenv("REFINEBIO_CONFIG_FILE") or str(Path.home()) + "/.refinebio.yaml"
+            )
 
             config = {}
 
@@ -70,7 +72,7 @@ class Config:
         """Save the config to a file
 
         The default path for this file is `~/.refinebio.yaml`
-        but it can be set using the environment variable `CONFIG_FILE`.
+        but it can be set using the environment variable `REFINEBIO_CONFIG_FILE`.
         """
         config = {"token": self.token, "base_url": self.base_url}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[pep8]
+max-line-length: 100
+
+[flake8]
+max-line-length: 100
+
+[isort]
+# Settings for compatibility with black.
+line_length = 100
+use_parentheses = True
+multi_line_output = 3
+include_trailing_comma = True
+combine_as_imports = True
+known_django=django, rest_framework
+known_first_party=data_refinery_api,data_refinery_common,data_refinery_foreman,data_refinery_workers
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+combine_star = true
+length_sort = false


### PR DESCRIPTION
Other projects may have base URLs, or in the context of another project it may be confusing what the env var is for.