### PR TITLE
Fix `--skip-quantile-normalization`

### DIFF
--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -183,24 +183,24 @@ class Dataset(Base):
         """
         body = {}
         body["data"] = self.data
-        if self.aggregate_by:
+        if self.aggregate_by is not None:
             body["aggregate_by"] = self.aggregate_by
-        if self.scale_by:
+        if self.scale_by is not None:
             body["scale_by"] = self.scale_by
-        if self.email_address:
+        if self.email_address is not None:
             body["email_address"] = self.email_address
-        if self.email_ccdl_ok:
+        if self.email_ccdl_ok is not None:
             body["email_ccdl_ok"] = self.email_ccdl_ok
-        if self.start:
+        if self.start is not None:
             body["start"] = self.start
-        if self.quantile_normalize:
+        if self.quantile_normalize is not None:
             body["quantile_normalize"] = self.quantile_normalize
-        if self.quant_sf_only:
+        if self.quant_sf_only is not None:
             body["quant_sf_only"] = self.quant_sf_only
-        if self.svd_algorithm:
+        if self.svd_algorithm is not None:
             body["svd_algorithm"] = self.svd_algorithm
 
-        if self.id:
+        if self.id is not None:
             response = put_by_endpoint("dataset/" + self.id, payload=body).json()
         else:
             response = post_by_endpoint("dataset", payload=body).json()

--- a/pyrefinebio/high_level_functions.py
+++ b/pyrefinebio/high_level_functions.py
@@ -136,8 +136,9 @@ def download_dataset(
             print(
                 (
                     "Dataset not processed after {0}. The system may be experiencing issues"
-                    " or your dataset may just be taking a while to process."
-                ).format(timeout)
+                    " or your dataset may just be taking a while to process. You can check on its"
+                    " progress at https://refine.bio/dataset/{1}"
+                ).format(timeout, dataset.id)
             )
             return None
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -146,7 +146,7 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
 
         # We need to use assertEqual here because None is False-y
         self.assertEqual(
-            mock_post_by_endpoint.call_args.kwargs.get("quantile_normalize", None), False
+            mock_post_by_endpoint.call_args.kwargs["payload"].get("quantile_normalize", None), False
         )
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -142,12 +142,11 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
             quantile_normalize=False,
         ).save()
 
-        mock_post_by_endpoint.assert_called_once()
+        self.assertEqual(mock_post_by_endpoint.call_count, 1)
 
         # We need to use assertEqual here because None is False-y
-        self.assertEqual(
-            mock_post_by_endpoint.call_args.kwargs["payload"].get("quantile_normalize", None), False
-        )
+        args, kwargs = mock_post_by_endpoint.call_args
+        self.assertEqual(kwargs["payload"].get("quantile_normalize", None), False)
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_dataset_process(self, mock_request):


### PR DESCRIPTION
Before, this option didn't actually do anything because we had the following:
```python3
if self.quantile_normalize:
  data["quantile_normalize"] = self.quantile_normalize
```
but the flag sets this value false, so the value never ends up getting added to the request. I fixed this by changing the check to `is not None` everywhere, and I added a test that fails before the fix was applied.