### PR TITLE
Change the email behavior to opt-in

### DIFF
--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -79,6 +79,8 @@ class Dataset(Base):
         quant_sf_only=None,
         svd_algorithm=None,
         download_url=None,
+        # Emails should be opt-in https://github.com/AlexsLemonade/refinebio-py/issues/58
+        notify_me=False,
     ):
         super().__init__(identifier=id)
 
@@ -106,6 +108,7 @@ class Dataset(Base):
         self.quant_sf_only = quant_sf_only
         self.svd_algorithm = svd_algorithm
         self.download_url = download_url
+        self.notify_me = notify_me
 
         self._downloaded_path = None
 
@@ -199,6 +202,8 @@ class Dataset(Base):
             body["quant_sf_only"] = self.quant_sf_only
         if self.svd_algorithm is not None:
             body["svd_algorithm"] = self.svd_algorithm
+        if self.notify_me is not None:
+            body["notify_me"] = self.notify_me
 
         if self.id is not None:
             response = put_by_endpoint("dataset/" + self.id, payload=body).json()

--- a/pyrefinebio/high_level_functions.py
+++ b/pyrefinebio/high_level_functions.py
@@ -54,6 +54,7 @@ def download_dataset(
     timeout=None,
     extract=False,
     prompt=True,
+    notify_me=False,
 ):
     """download_dataset
 
@@ -98,6 +99,9 @@ def download_dataset(
         extract (bool): if true, the downloaded zip file will be automatically extracted
 
         prompt (bool): if true, will prompt before downloading files bigger than 1GB
+
+        notify_me (bool): if true, refine.bio will send you an email when the dataset has finished processing.
+                          Defaults to False.
     """
     if dataset_dict and experiments:
         raise DownloadError(
@@ -111,6 +115,7 @@ def download_dataset(
         email_address=email_address,
         aggregate_by=aggregation,
         quantile_normalize=(not skip_quantile_normalization),
+        notify_me=notify_me,
     )
 
     if dataset_dict:

--- a/pyrefinebio/script.py
+++ b/pyrefinebio/script.py
@@ -114,6 +114,12 @@ def describe(entity=None):
     type=TimedeltaParamType(),
     help="A string representing how long to wait for the dataset to process such as '15 minutes'.",
 )
+@click.option(
+    "--notify-me",
+    default=False,
+    type=click.BOOL,
+    help="Control whether or not refine.bio should send you an email when your Dataset has finished processing.",
+)
 def download_dataset(
     email_address,
     path,
@@ -123,6 +129,7 @@ def download_dataset(
     transformation,
     skip_quantile_normalization,
     timeout,
+    notify_me,
 ):
     """
     Automatically constructs a Dataset, processes it, waits for it
@@ -138,6 +145,7 @@ def download_dataset(
             transformation,
             skip_quantile_normalization,
             timeout=timeout,
+            notify_me=notify_me,
         )
     except DownloadError as e:
         raise click.ClickException(str(e))

--- a/pyrefinebio/script.py
+++ b/pyrefinebio/script.py
@@ -116,8 +116,7 @@ def describe(entity=None):
 )
 @click.option(
     "--notify-me",
-    default=False,
-    type=click.BOOL,
+    is_flag=True,
     help="Control whether or not refine.bio should send you an email when your Dataset has finished processing.",
 )
 def download_dataset(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -149,7 +149,7 @@ class DatasetTests(unittest.TestCase, CustomAssertions):
 
         # We need to use assertEqual here because None is False-y
         self.assertEqual(
-            mock_post_by_endpoint.call_args.kwargs.get("quantile_normalize", None), False
+            mock_post_by_endpoint.call_args.kwargs["payload"].get("quantile_normalize", None), False
         )
 
     @patch("pyrefinebio.dataset.post_by_endpoint")

--- a/tests/test_high_level_functions.py
+++ b/tests/test_high_level_functions.py
@@ -9,26 +9,18 @@ from tests.mocks import MockResponse
 
 
 class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
-
     @patch("pyrefinebio.dataset.download_file")
     @patch("pyrefinebio.dataset.get_by_endpoint")
     @patch("pyrefinebio.dataset.post_by_endpoint")
     def test_download_dataset_dataset_dict(self, mock_post, mock_get, mock_download):
         mr = MockResponse(
-            {
-                "id": "test_dataset",
-                "is_processed": True,
-                "download_url": "test_url"
-            },
-            "url"
+            {"id": "test_dataset", "is_processed": True, "download_url": "test_url"}, "url"
         )
 
         mock_get.return_value = mr
         mock_post.return_value = mr
 
-        dataset_dict = {
-            "test": ["foo", "bar"]
-        }
+        dataset_dict = {"test": ["foo", "bar"]}
 
         pyrefinebio.download_dataset("test", "foo@test.com", dataset_dict=dataset_dict)
 
@@ -39,24 +31,50 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
                 "aggregate_by": "EXPERIMENT",
                 "email_address": "foo@test.com",
                 "start": True,
-                "quantile_normalize": True
-            }
+                "quantile_normalize": True,
+                "notify_me": False,
+            },
         )
 
         mock_download.assert_called_with("test_url", os.path.abspath("test"), True)
 
+    @patch("pyrefinebio.dataset.download_file")
+    @patch("pyrefinebio.dataset.get_by_endpoint")
+    @patch("pyrefinebio.dataset.post_by_endpoint")
+    def test_download_dataset_notify_me(self, mock_post, mock_get, mock_download):
+        mr = MockResponse(
+            {"id": "test_dataset", "is_processed": True, "download_url": "test_url"}, "url"
+        )
+
+        mock_get.return_value = mr
+        mock_post.return_value = mr
+
+        dataset_dict = {"test": ["foo", "bar"]}
+
+        pyrefinebio.download_dataset(
+            "test", "foo@test.com", dataset_dict=dataset_dict, notify_me=True
+        )
+
+        mock_post.assert_called_with(
+            "dataset",
+            payload={
+                "data": dataset_dict,
+                "aggregate_by": "EXPERIMENT",
+                "email_address": "foo@test.com",
+                "start": True,
+                "quantile_normalize": True,
+                "notify_me": True,
+            },
+        )
+
+        mock_download.assert_called_with("test_url", os.path.abspath("test"), True)
 
     @patch("pyrefinebio.dataset.download_file")
     @patch("pyrefinebio.dataset.get_by_endpoint")
     @patch("pyrefinebio.dataset.post_by_endpoint")
     def test_download_dataset_experiments(self, mock_post, mock_get, mock_download):
         mr = MockResponse(
-            {
-                "id": "test_dataset",
-                "is_processed": True,
-                "download_url": "test_url"
-            },
-            "url"
+            {"id": "test_dataset", "is_processed": True, "download_url": "test_url"}, "url"
         )
 
         mock_get.return_value = mr
@@ -64,24 +82,23 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
 
         experiment2 = pyrefinebio.Experiment(accession_code="test-experiment-2")
 
-        pyrefinebio.download_dataset("test", "foo@test.com", experiments=["test-experiment-1", experiment2])
+        pyrefinebio.download_dataset(
+            "test", "foo@test.com", experiments=["test-experiment-1", experiment2]
+        )
 
         mock_post.assert_called_with(
             "dataset",
             payload={
-                "data": {
-                    "test-experiment-1": ["ALL"],
-                    "test-experiment-2": ["ALL"]
-                },
+                "data": {"test-experiment-1": ["ALL"], "test-experiment-2": ["ALL"]},
                 "aggregate_by": "EXPERIMENT",
                 "email_address": "foo@test.com",
                 "start": True,
-                "quantile_normalize": True
-            }
+                "quantile_normalize": True,
+                "notify_me": False,
+            },
         )
 
         mock_download.assert_called_with("test_url", os.path.abspath("test"), True)
-
 
     @patch("pyrefinebio.dataset.shutil.unpack_archive")
     @patch("pyrefinebio.dataset.download_file")
@@ -89,20 +106,13 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.dataset.post_by_endpoint")
     def test_download_dataset_extract(self, mock_post, mock_get, mock_download, mock_unpack):
         mr = MockResponse(
-            {
-                "id": "test_dataset",
-                "is_processed": True,
-                "download_url": "test_url"
-            },
-            "url"
+            {"id": "test_dataset", "is_processed": True, "download_url": "test_url"}, "url"
         )
 
         mock_get.return_value = mr
         mock_post.return_value = mr
 
-        dataset_dict = {
-            "test": ["foo", "bar"]
-        }
+        dataset_dict = {"test": ["foo", "bar"]}
 
         pyrefinebio.download_dataset("./", "foo@test.com", dataset_dict=dataset_dict, extract=True)
 
@@ -111,11 +121,11 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
         mock_download.assert_called_with("test_url", expected_path, True)
         mock_unpack.assert_called_with(expected_path)
 
-
     def test_download_dataset_both(self):
         with self.assertRaises(pyrefinebio.exceptions.DownloadError):
-            pyrefinebio.download_dataset("test", "foo@test.com", dataset_dict={"bad"}, experiments=["bad"])
-
+            pyrefinebio.download_dataset(
+                "test", "foo@test.com", dataset_dict={"bad"}, experiments=["bad"]
+            )
 
     @patch("pyrefinebio.compendia.download_file")
     @patch("pyrefinebio.compendia.get_by_endpoint")
@@ -125,30 +135,23 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
                 "count": 1,
                 "next": None,
                 "previous": None,
-                "results": [
-                    {
-                        "computed_file": {
-                            "download_url": "test_url"
-                        }
-                    }
-                ]
+                "results": [{"computed_file": {"download_url": "test_url"}}],
             },
-            "url"
+            "url",
         )
 
         pyrefinebio.download_compendium("test", "test_organism")
-        
+
         mock_get.assert_called_with(
             "compendia",
             params={
                 "primary_organism__name": "test_organism",
                 "quant_sf_only": False,
-                "latest_version": True
-            }
+                "latest_version": True,
+            },
         )
 
         mock_download.assert_called_with("test_url", os.path.abspath("test"), True)
-
 
     @patch("pyrefinebio.compendia.shutil.unpack_archive")
     @patch("pyrefinebio.compendia.download_file")
@@ -159,16 +162,9 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
                 "count": 1,
                 "next": None,
                 "previous": None,
-                "results": [
-                    {
-                        "id": 123,
-                        "computed_file": {
-                            "download_url": "test_url"
-                        }
-                    }
-                ]
+                "results": [{"id": 123, "computed_file": {"download_url": "test_url"}}],
             },
-            "url"
+            "url",
         )
 
         pyrefinebio.download_compendium("./", "test_organism", extract=True)
@@ -178,11 +174,9 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
         mock_download.assert_called_with("test_url", expected_path, True)
         mock_unpack.assert_called_with(expected_path)
 
-
     def test_download_compendium_no_results(self):
         with self.assertRaises(pyrefinebio.exceptions.DownloadError):
             pyrefinebio.download_compendium("test", "this-will-have-no-results")
-
 
     @patch("pyrefinebio.computed_file.get_by_endpoint")
     @patch("pyrefinebio.compendia.get_by_endpoint")
@@ -192,28 +186,16 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
                 "count": 1,
                 "next": None,
                 "previous": None,
-                "results": [
-                    {
-                        "computed_file": {
-                            "download_url": None
-                        }
-                    }
-                ]
+                "results": [{"computed_file": {"download_url": None}}],
             },
-            "url"
+            "url",
         )
 
-        mock_computed_file_get.return_value = MockResponse(
-            {
-                "download_url": None
-            },
-            "url"
-        )
+        mock_computed_file_get.return_value = MockResponse({"download_url": None}, "url")
 
         with self.assertRaises(pyrefinebio.exceptions.DownloadError):
             pyrefinebio.download_compendium("test", "test_organism")
 
-    
     @patch("pyrefinebio.high_level_functions.Token")
     @patch("pyrefinebio.high_level_functions.input")
     def test_create_token_with_prompt(self, mock_input, mock_token):
@@ -225,7 +207,6 @@ class HighLevelFunctionTests(unittest.TestCase, CustomAssertions):
 
         self.assertTrue(mock_created_token.agree_to_terms_and_conditions.called)
         self.assertTrue(mock_created_token.save_token.called)
-
 
     @patch("pyrefinebio.high_level_functions.Token")
     @patch("pyrefinebio.high_level_functions.input")

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -33,6 +33,36 @@ class ScriptTests(unittest.TestCase):
             "NONE",
             False,
             timeout=None,
+            notify_me=False,
+        )
+
+    @patch("pyrefinebio.script.hlf.download_dataset")
+    def test_download_dataset_notify_me(self, mock_download_dataset):
+        self.runner.invoke(
+            cli,
+            [
+                "download-dataset",
+                "--email-address",
+                "foo@bar.net",
+                "--path",
+                "./test.zip",
+                "--dataset-dict",
+                '{"foo": ["bar"]}',
+                "--notify-me",
+                "True",
+            ],
+        )
+
+        mock_download_dataset.assert_called_with(
+            "./test.zip",
+            "foo@bar.net",
+            {"foo": ["bar"]},
+            None,
+            "EXPERIMENT",
+            "NONE",
+            False,
+            timeout=None,
+            notify_me=True,
         )
 
     @patch("pyrefinebio.script.hlf.download_dataset")
@@ -59,6 +89,7 @@ class ScriptTests(unittest.TestCase):
             "NONE",
             False,
             timeout=None,
+            notify_me=False,
         )
 
     @patch("pyrefinebio.script.hlf.download_dataset")
@@ -77,6 +108,7 @@ class ScriptTests(unittest.TestCase):
             "NONE",
             False,
             timeout=None,
+            notify_me=False,
         )
 
     def test_download_dataset_both(self):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -49,7 +49,6 @@ class ScriptTests(unittest.TestCase):
                 "--dataset-dict",
                 '{"foo": ["bar"]}',
                 "--notify-me",
-                "True",
             ],
         )
 


### PR DESCRIPTION
Fixes https://github.com/AlexsLemonade/refinebio-py/issues/58 by adding a command-line flag `--notify-me` and a corresponding field on the `Dataset` class.

Marking this as a draft for now because it depends on https://github.com/AlexsLemonade/refinebio/pull/2796