### PR TITLE
Fix the lazy loading of files for jobs and samples, and results for tx indices.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 2
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
 

--- a/pyrefinebio/base.py
+++ b/pyrefinebio/base.py
@@ -1,5 +1,6 @@
 from pprint import pformat
 
+
 class Base(object):
     """Base class that all pyrefinebio classes inherit from.
 
@@ -10,10 +11,14 @@ class Base(object):
         self._identifier = identifier
         self._fetched = False
 
-
     def __str__(self):
         return pformat(self._to_dict())
 
+    def __eq__(self, other):
+        try:
+            return self._identifier == other._identifier
+        except AttributeError:
+            return False
 
     def _to_dict(self):
         expanded = {}
@@ -26,9 +31,12 @@ class Base(object):
 
         return expanded
 
-
     def __getattribute__(self, attr):
-        if not attr.startswith("_") and object.__getattribute__(self, attr) is None and not self._fetched:
+        if (
+            not attr.startswith("_")
+            and object.__getattribute__(self, attr) is None
+            and not self._fetched
+        ):
             # if somehow the identifier isn't set we can't fetch
             # this will only happen with Datasets which can be created by non-api calls
             if self._identifier:

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -1,7 +1,6 @@
 import shutil
 
-import pyrefinebio.experiment as prb_experiment
-import pyrefinebio.sample as prb_sample
+from pyrefinebio import experiment as prb_experiment, sample as prb_sample
 from pyrefinebio.api_interface import (
     download_file,
     get_by_endpoint,

--- a/pyrefinebio/job.py
+++ b/pyrefinebio/job.py
@@ -1,3 +1,4 @@
+from pyrefinebio import original_file as prb_original_file
 from pyrefinebio.api_interface import get_by_endpoint
 from pyrefinebio.base import Base
 from pyrefinebio.util import create_paginated_list, parse_date
@@ -32,7 +33,7 @@ class DownloaderJob(Base):
         batch_job_queue=None,
         failure_reason=None,
         success=None,
-        original_files=None,
+        original_files=[],
         start_time=None,
         end_time=None,
         created_at=None,
@@ -53,12 +54,17 @@ class DownloaderJob(Base):
         self.batch_job_queue = batch_job_queue
         self.failure_reason = failure_reason
         self.success = success
-        self.original_files = original_files
         self.start_time = parse_date(start_time)
         self.end_time = parse_date(end_time)
         self.created_at = parse_date(created_at)
         self.last_modified = parse_date(last_modified)
         self.is_queued = is_queued
+
+        self.original_files = (
+            [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
+            if original_files
+            else []
+        )
 
     @classmethod
     def get(cls, id):
@@ -155,7 +161,7 @@ class ProcessorJob(Base):
         batch_job_id=None,
         batch_job_queue=None,
         success=None,
-        original_files=None,
+        original_files=[],
         datasets=None,
         start_time=None,
         end_time=None,
@@ -177,13 +183,18 @@ class ProcessorJob(Base):
         self.batch_job_id = batch_job_id
         self.batch_job_queue = batch_job_queue
         self.success = success
-        self.original_files = original_files
         self.datasets = datasets
         self.start_time = parse_date(start_time)
         self.end_time = parse_date(end_time)
         self.created_at = parse_date(created_at)
         self.last_modified = parse_date(last_modified)
         self.is_queued = is_queued
+
+        self.original_files = (
+            [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
+            if original_files
+            else []
+        )
 
     @classmethod
     def get(cls, id):

--- a/pyrefinebio/original_file.py
+++ b/pyrefinebio/original_file.py
@@ -1,5 +1,4 @@
-import pyrefinebio.job as prb_job
-import pyrefinebio.sample as prb_sample
+from pyrefinebio import job as prb_job, sample as prb_sample
 from pyrefinebio.api_interface import get_by_endpoint
 from pyrefinebio.base import Base
 from pyrefinebio.util import create_paginated_list, parse_date

--- a/pyrefinebio/qn_target.py
+++ b/pyrefinebio/qn_target.py
@@ -1,4 +1,4 @@
-import pyrefinebio.organism as prb_organism
+from pyrefinebio import organism as prb_organism
 from pyrefinebio.api_interface import get_by_endpoint
 from pyrefinebio.base import Base
 from pyrefinebio.util import parse_date

--- a/pyrefinebio/sample.py
+++ b/pyrefinebio/sample.py
@@ -1,8 +1,10 @@
 from pyrefinebio import (
     annotation as prb_annotation,
     computational_result as prb_computational_result,
+    computed_file as prb_computed_file,
     experiment as prb_experiment,
     organism as prb_organism,
+    original_file as prb_original_file,
 )
 from pyrefinebio.api_interface import get_by_endpoint
 from pyrefinebio.base import Base
@@ -56,8 +58,8 @@ class Sample(Base):
         is_processed=None,
         created_at=None,
         last_modified=None,
-        original_files=None,
-        computed_files=None,
+        original_files=[],
+        computed_files=[],
         experiment_accession_codes=None,
         experiments=None,
     ):
@@ -101,8 +103,18 @@ class Sample(Base):
         self.is_processed = is_processed
         self.created_at = parse_date(created_at)
         self.last_modified = parse_date(last_modified)
-        self.original_files = original_files
-        self.computed_files = computed_files
+
+        self.original_files = (
+            [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
+            if original_files
+            else []
+        )
+        self.computed_files = (
+            [prb_computed_file.ComputedFile(id=file_id) for file_id in computed_files]
+            if computed_files
+            else []
+        )
+
         self.experiment_accession_codes = experiment_accession_codes
         self.experiments = experiments
 

--- a/pyrefinebio/transcriptome_index.py
+++ b/pyrefinebio/transcriptome_index.py
@@ -1,3 +1,4 @@
+from pyrefinebio import computational_result as prb_computational_result
 from pyrefinebio.api_interface import get_by_endpoint
 from pyrefinebio.base import Base
 from pyrefinebio.util import create_paginated_list, parse_date
@@ -42,6 +43,7 @@ class TranscriptomeIndex(Base):
         self.salmon_version = salmon_version
         self.download_url = download_url
         self.result_id = result_id
+        self.result = prb_computational_result.ComputationalResult(id=result_id)
         self.last_modified = parse_date(last_modified)
 
     @classmethod

--- a/tests/custom_assertions.py
+++ b/tests/custom_assertions.py
@@ -1,25 +1,23 @@
 from datetime import datetime
 
-class CustomAssertions:
 
+class CustomAssertions:
     def assertObject(self, actual, expected):
         """Assert that a model is equivalent to its dict counterpart.
 
         Verifies that all properties have been set correctly
         Verifies that all set properties can be accessed by dot notation
         """
-
         # if actual and expected are the same type, just compare with ==
         if type(actual) == type(expected):
             if actual != expected:
                 raise AssertionError(
                     "actual did not match expected value:\nexpected: {0}\nactual: {1}".format(
-                        expected,
-                        actual
+                        expected, actual
                     )
                 )
             return
-        
+
         if isinstance(actual, datetime):
             if actual.microsecond:
                 actual = datetime.strftime(actual, "%Y-%m-%dT%H:%M:%S.%fZ")
@@ -28,12 +26,10 @@ class CustomAssertions:
             if actual != expected:
                 raise AssertionError(
                     "actual did not match expected value:\nexpected: {0}\nactual: {1}".format(
-                        expected,
-                        actual
+                        expected, actual
                     )
                 )
             return
-
 
         # if we get here, actual is an model class object so do the complicated logic
         for key, value in expected.items():
@@ -43,17 +39,12 @@ class CustomAssertions:
                 if len(value) != len(actual_value):
                     raise AssertionError(
                         "actual.{0} did not match expected value:\nexpected: {1} - length: {2}\nactual: {3} - length: {4}".format(
-                            key,
-                            value,
-                            len(value),
-                            actual_value,
-                            len(actual_value)
+                            key, value, len(value), actual_value, len(actual_value)
                         )
                     )
 
                 for i in range(len(value)):
                     self.assertObject(actual_value[i], value[i])
-            
+
             else:
                 self.assertObject(actual_value, value)
-

--- a/tests/test_downloader_job.py
+++ b/tests/test_downloader_job.py
@@ -1,7 +1,9 @@
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 import pyrefinebio
+from pyrefinebio import original_file as prb_original_file
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 
@@ -43,6 +45,18 @@ job_2 = {
     "last_modified": "2020-06-25T10:07:56.601791Z",
 }
 
+job_1_object_dict = deepcopy(job_1)
+
+job_1_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in job_1["original_files"]
+]
+
+job_2_object_dict = deepcopy(job_2)
+
+job_2_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in job_2["original_files"]
+]
+
 search_1 = {"count": 2, "next": "search_2", "previous": None, "results": [job_1]}
 
 search_2 = {"count": 2, "next": None, "previous": "search_1", "results": [job_2]}
@@ -73,7 +87,7 @@ class DownloaderJobTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_downloader_job_get(self, mock_request):
         result = pyrefinebio.DownloaderJob.get(1)
-        self.assertObject(result, job_1)
+        self.assertObject(result, job_1_object_dict)
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_downloader_job_500(self, mock_request):
@@ -89,8 +103,8 @@ class DownloaderJobTests(unittest.TestCase, CustomAssertions):
     def test_downloader_job_search_no_filters(self, mock_request):
         results = pyrefinebio.DownloaderJob.search()
 
-        self.assertObject(results[0], job_1)
-        self.assertObject(results[1], job_2)
+        self.assertObject(results[0], job_1_object_dict)
+        self.assertObject(results[1], job_2_object_dict)
 
     def test_downloader_job_search_with_filters(self):
         filtered_results = pyrefinebio.DownloaderJob.search(

--- a/tests/test_original_file.py
+++ b/tests/test_original_file.py
@@ -1,7 +1,9 @@
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 import pyrefinebio
+from pyrefinebio import job as prb_job, original_file as prb_original_file
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 
@@ -26,6 +28,12 @@ processor_job = {
     "last_modified": "2020-10-01T20:23:43.508066Z",
 }
 
+processor_job_object_dict = deepcopy(processor_job)
+
+processor_job_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in processor_job["original_files"]
+]
+
 downloader_job = {
     "id": 7381811,
     "downloader_task": "SRA",
@@ -45,6 +53,12 @@ downloader_job = {
     "last_modified": "2020-10-01T20:19:05.873426Z",
 }
 
+downloader_job_object_dict = deepcopy(downloader_job)
+
+downloader_job_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in processor_job["original_files"]
+]
+
 og_file_1 = {
     "id": 1,
     "filename": "SRR067396.sra",
@@ -59,8 +73,8 @@ og_file_1 = {
             "is_processed": True,
         }
     ],
-    "processor_jobs": [processor_job],
-    "downloader_jobs": [downloader_job],
+    "processor_jobs": [processor_job_object_dict],
+    "downloader_jobs": [downloader_job_object_dict],
     "source_url": "anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/SRR/SRR067/SRR067396/SRR067396.sra",
     "source_filename": "SRR067396.sra",
     "is_downloaded": False,

--- a/tests/test_processor_job.py
+++ b/tests/test_processor_job.py
@@ -1,7 +1,9 @@
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 import pyrefinebio
+from pyrefinebio import original_file as prb_original_file
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 
@@ -47,6 +49,18 @@ job_2 = {
     "last_modified": "2020-10-14T17:02:12.658330Z",
 }
 
+job_1_object_dict = deepcopy(job_1)
+
+job_1_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in job_1["original_files"]
+]
+
+job_2_object_dict = deepcopy(job_2)
+
+job_2_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in job_2["original_files"]
+]
+
 search_1 = {"count": 2, "next": "search_2", "previous": None, "results": [job_1]}
 
 search_2 = {"count": 2, "next": None, "previous": "search_1", "results": [job_2]}
@@ -77,7 +91,7 @@ class ProcessorJobTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_processor_job_get(self, mock_request):
         result = pyrefinebio.ProcessorJob.get(1)
-        self.assertObject(result, job_1)
+        self.assertObject(result, job_1_object_dict)
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_processor_job_500(self, mock_request):
@@ -93,8 +107,8 @@ class ProcessorJobTests(unittest.TestCase, CustomAssertions):
     def test_processor_job_search_no_filters(self, mock_request):
         results = pyrefinebio.ProcessorJob.search()
 
-        self.assertObject(results[0], job_1)
-        self.assertObject(results[1], job_2)
+        self.assertObject(results[0], job_1_object_dict)
+        self.assertObject(results[1], job_2_object_dict)
 
     def test_processor_job_search_with_filters(self):
         filtered_results = pyrefinebio.ProcessorJob.search(

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,7 +1,9 @@
 import unittest
-from unittest.mock import Mock, patch
+from copy import deepcopy
+from unittest.mock import patch
 
 import pyrefinebio
+from pyrefinebio import computed_file as prb_computed_file, original_file as prb_original_file
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
 from tests.test_experiment import experiment_search_result_1, experiment_search_result_2
@@ -193,6 +195,24 @@ sample_2 = {
     "experiment_accession_codes": ["GSE63990"],
 }
 
+sample_1_object_dict = deepcopy(sample_1)
+
+sample_1_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in sample_1["original_files"]
+]
+sample_1_object_dict["computed_files"] = [
+    prb_computed_file.ComputedFile(file_id) for file_id in sample_1["computed_files"]
+]
+
+sample_2_object_dict = deepcopy(sample_2)
+
+sample_2_object_dict["original_files"] = [
+    prb_original_file.OriginalFile(file_id) for file_id in sample_2["original_files"]
+]
+sample_2_object_dict["computed_files"] = [
+    prb_computed_file.ComputedFile(file_id) for file_id in sample_2["computed_files"]
+]
+
 result = {
     "id": 1339595,
     "commands": [
@@ -293,7 +313,7 @@ class SampleTests(unittest.TestCase, CustomAssertions):
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_sample_get(self, mock_request):
         result = pyrefinebio.Sample.get("SRR5445147")
-        self.assertObject(result, sample_1)
+        self.assertObject(result, sample_1_object_dict)
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)
     def test_sample_500(self, mock_request):
@@ -315,8 +335,8 @@ class SampleTests(unittest.TestCase, CustomAssertions):
     def test_sample_search_no_filters(self, mock_request):
         results = pyrefinebio.Sample.search()
 
-        self.assertObject(results[0], sample_1)
-        self.assertObject(results[1], sample_2)
+        self.assertObject(results[0], sample_1_object_dict)
+        self.assertObject(results[1], sample_2_object_dict)
 
     def test_sample_search_with_filters(self):
         filtered_results = pyrefinebio.Sample.search(organism=258, has_raw=True, is_processed=False)


### PR DESCRIPTION
#51 

These only had ids. This fixes that to give them the lazy loading objects.

Unit tests are passing

Functional test:

```
In [10]: print(djs[0].original_files[0])
{'created_at': None,
 'downloader_jobs': [],
 'filename': None,
 'has_raw': None,
 'id': 2641843,
 'is_archive': None,
 'is_downloaded': None,
 'last_modified': None,
 'processor_jobs': [],
 'samples': [],
 'sha1': None,
 'size_in_bytes': None,
 'source_filename': None,
 'source_url': None}

In [11]: print(djs[0].original_files[0].size_in_bytes)
738907914
```