### PR TITLE
Fix lazy loading for original files

### DIFF
--- a/pyrefinebio/base.py
+++ b/pyrefinebio/base.py
@@ -34,7 +34,10 @@ class Base(object):
     def __getattribute__(self, attr):
         if (
             not attr.startswith("_")
-            and object.__getattribute__(self, attr) is None
+            and (
+                object.__getattribute__(self, attr) is None
+                or object.__getattribute__(self, attr) == []
+            )
             and not self._fetched
         ):
             # if somehow the identifier isn't set we can't fetch

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -59,7 +59,7 @@ class Config:
 
             if os.path.exists(cls.config_file):
                 with open(cls.config_file) as config_file:
-                    config = yaml.full_load(config_file) or {}
+                    config = yaml.safe_load(config_file) or {}
 
             cls.token = os.getenv("REFINEBIO_TOKEN") or config.get("token", "")
             cls.base_url = os.getenv("REFINEBIO_BASE_URL") or config.get(

--- a/pyrefinebio/job.py
+++ b/pyrefinebio/job.py
@@ -60,11 +60,17 @@ class DownloaderJob(Base):
         self.last_modified = parse_date(last_modified)
         self.is_queued = is_queued
 
-        self.original_files = (
-            [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
-            if original_files
-            else []
-        )
+        original_files_list = []
+        if original_files:
+            for original_file in original_files:
+                if type(original_file) is dict:
+                    original_files_list.append(prb_original_file.OriginalFile(**original_file))
+                elif type(original_file) is int:
+                    original_files_list.append(prb_original_file.OriginalFile(id=original_file))
+                else:
+                    original_files_list.append(original_file)
+
+        self.original_files = original_files_list
 
     @classmethod
     def get(cls, id):
@@ -190,11 +196,17 @@ class ProcessorJob(Base):
         self.last_modified = parse_date(last_modified)
         self.is_queued = is_queued
 
-        self.original_files = (
-            [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
-            if original_files
-            else []
-        )
+        original_files_list = []
+        if original_files:
+            for original_file in original_files:
+                if type(original_file) is dict:
+                    original_files_list.append(prb_original_file.OriginalFile(**original_file))
+                elif type(original_file) is int:
+                    original_files_list.append(prb_original_file.OriginalFile(id=original_file))
+                else:
+                    original_files_list.append(original_file)
+
+        self.original_files = original_files_list
 
     @classmethod
     def get(cls, id):

--- a/pyrefinebio/original_file.py
+++ b/pyrefinebio/original_file.py
@@ -42,29 +42,35 @@ class OriginalFile(Base):
         self.filename = filename
         self.size_in_bytes = size_in_bytes
         self.sha1 = sha1
-        self.samples = []
+        samples_list = []
         if samples:
             for sample in samples:
                 if type(sample) is dict:
-                    self.samples.append(prb_sample.Sample(**sample))
+                    samples_list.append(prb_sample.Sample(**sample))
                 else:
-                    self.samples.append(sample)
+                    samples_list.append(sample)
 
-        self.processor_jobs = []
+        self.samples = samples_list
+
+        processor_jobs_list = []
         if processor_jobs:
             for processor_job in processor_jobs:
                 if type(processor_job) is dict:
-                    self.processor_jobs.append(prb_job.ProcessorJob(**processor_job))
+                    processor_jobs_list.append(prb_job.ProcessorJob(**processor_job))
                 else:
-                    self.processor_jobs.append(processor_job)
+                    processor_jobs_list.append(processor_job)
 
-        self.downloader_jobs = []
+        self.processor_jobs = processor_jobs_list
+
+        downloader_jobs_list = []
         if downloader_jobs:
             for downloader_job in downloader_jobs:
                 if type(downloader_job) is dict:
-                    self.downloader_jobs.append(prb_job.DownloaderJob(**downloader_job))
+                    downloader_jobs_list.append(prb_job.DownloaderJob(**downloader_job))
                 else:
-                    self.downloader_jobs.append(downloader_job)
+                    downloader_jobs_list.append(downloader_job)
+
+        self.downloader_jobs = downloader_jobs_list
 
         self.source_url = source_url
         self.source_filename = source_filename

--- a/pyrefinebio/util.py
+++ b/pyrefinebio/util.py
@@ -1,6 +1,6 @@
 import os
 
-from dateutil import parser
+import iso8601
 from pyrefinebio.api_interface import get
 
 
@@ -11,7 +11,7 @@ def create_paginated_list(T, response):
 def parse_date(date):
     try:
         parsed = None
-        parsed = parser.isoparse(date)
+        parsed = iso8601.parse_date(date)
     finally:
         return parsed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ click==7.1.2
 python-dateutil==2.8.1
 PyYAML==5.3.1
 requests==2.24.0
-pytimeparse==1.1.8
+iso8601==0.1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==7.1.2
-python-dateutil==2.8.1
+iso8601==0.1.16
 PyYAML==5.3.1
 requests==2.24.0
-iso8601==0.1.16
+pytimeparse==1.1.8

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "Operating System :: OS Independent",  # not sure if this is actually true - we should probably test on windows!
     ],
     python_requires=">=3.6",
-    install_requires=["python-dateutil", "PyYAML", "requests", "Click", "pytimeparse"],
+    install_requires=["iso8601", "PyYAML", "requests", "Click", "pytimeparse"],
     entry_points="""
         [console_scripts]
         refinebio=pyrefinebio.script:cli

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -63,7 +63,7 @@ experiment_search_result_1 = {
     "sample_metadata_fields": ["specimen_part", "disease", "subject"],
     "platform_names": ["Illumina HiSeq 2500"],
     "platform_accession_codes": ["IlluminaHiSeq2500"],
-    "organism_names": [],
+    "organism_names": ["HUMAN"],
     "pubmed_id": "30382198",
     "num_total_samples": 28706,
     "num_processed_samples": 0,

--- a/tests/test_original_file.py
+++ b/tests/test_original_file.py
@@ -56,7 +56,7 @@ downloader_job = {
 downloader_job_object_dict = deepcopy(downloader_job)
 
 downloader_job_object_dict["original_files"] = [
-    prb_original_file.OriginalFile(file_id) for file_id in processor_job["original_files"]
+    prb_original_file.OriginalFile(file_id) for file_id in downloader_job["original_files"]
 ]
 
 og_file_1 = {

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -341,6 +341,7 @@ class SampleTests(unittest.TestCase, CustomAssertions):
     def test_sample_search_with_filters(self):
         filtered_results = pyrefinebio.Sample.search(organism=258, has_raw=True, is_processed=False)
 
+        self.assertGreater(len(filtered_results), 0)
         for result in filtered_results:
             self.assertEqual(result.organism.name, "MUS")
             self.assertTrue(result.has_raw)


### PR DESCRIPTION
Related: #62 

We use empty list as a default when we haven't loaded, so we also should check for that in the base.__getattribute__(). However adding that caused an infinite loop because `self.downloader_jobs.append()` was triggering a fetch on the original file. Therefore this also prevents original files from triggering a fetch on themselves by building the list of related objects and then setting it on `self`.