### PR TITLE
Handle errors due to non-json responses

### DIFF
--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -30,7 +30,10 @@ def request(method, url, params=None, payload=None):
 
     except requests.exceptions.HTTPError as e:
         code = response.status_code
-        response_body = response.json()
+        try:
+            response_body = response.json()
+        except json.decoder.JSONDecodeError:
+            response_body = response.text
 
         if code == 400:
             error = _handle_error(response_body)

--- a/tests/test_api_interface.py
+++ b/tests/test_api_interface.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+
+import pyrefinebio
+from pyrefinebio.exceptions import BadRequest, NotFound
+from tests.custom_assertions import CustomAssertions
+from tests.mocks import MockResponse
+
+
+def mock_400_request(method, url, **kwargs):
+    return MockResponse(
+        "we're not home right now", "https://api.refine.bio/v1/organisms/GORILLA", 400
+    )
+
+
+def mock_404_request(method, url, **kwargs):
+    return MockResponse(
+        "we're not home right now", "https://api.refine.bio/v1/organisms/GORILLA", 404
+    )
+
+
+class ApiInterfaceTests(unittest.TestCase, CustomAssertions):
+    @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_400_request)
+    def test_400(self, mock_request):
+        with self.assertRaises(BadRequest):
+            pyrefinebio.Organism.get("GORILLA")
+
+    @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_404_request)
+    def test_404(self, mock_request):
+        with self.assertRaises(NotFound):
+            pyrefinebio.Organism.get("GORILLA")


### PR DESCRIPTION
I think that when the API is coming up I think nginx sometimes returns responses that aren't JSON. This probably is a super minor problem, except that it seems to happen frequently in our end to end tests.