### PR TITLE
Catch all 5xx errors.

### DIFF
--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -42,7 +42,7 @@ def request(method, url, params=None, payload=None):
         elif code == 404:
             raise NotFound(response.url)
 
-        elif code == 500 or code == 502:
+        elif code >= 500:
             raise ServerError()
 
         else:

--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -42,7 +42,7 @@ def request(method, url, params=None, payload=None):
         elif code == 404:
             raise NotFound(response.url)
 
-        elif code == 500:
+        elif code == 500 or code == 502:
             raise ServerError()
 
         else:


### PR DESCRIPTION
Minor change because I saw this stacktrace in refinebio end to end tests:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/home/user/data_refinery_foreman/foreman/test_end_to_end.py", line 178, in test_smasher_job
    pyrefinebio.create_token(agree_to_terms=True, save_token=False)
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/high_level_functions.py", line 275, in create_token
    token = Token()
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/token.py", line 46, in __init__
    response = post_by_endpoint("token", payload={"email_address": email_address}).json()
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/api_interface.py", line 76, in post_by_endpoint
    return post(url, payload=payload)
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/api_interface.py", line 60, in post
    return request("POST", url, payload=payload)
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/api_interface.py", line 50, in request
    raise e
  File "/usr/local/lib/python3.6/dist-packages/pyrefinebio/api_interface.py", line 27, in request
    response.raise_for_status()
  File "/usr/local/lib/python3.6/dist-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: http://54.236.120.207/v1/token/
```