### PR TITLE
Attempt to add extract_dir specification

### DIFF
--- a/pyrefinebio/compendia.py
+++ b/pyrefinebio/compendia.py
@@ -117,9 +117,12 @@ class Compendium(Base):
 
         return self
 
-    def extract(self):
+    def extract(self, path):
         """Extract a downloaded Compendium
 
+        Parameters:
+            path (str): the path that the Dataset should be extracted to
+            
         Returns:
             Compendium
         """
@@ -129,5 +132,5 @@ class Compendium(Base):
                 "Make sure you have successfully downloaded the Compendium before extracting.",
             )
 
-        shutil.unpack_archive(self._downloaded_path)
+        shutil.unpack_archive(self._downloaded_path, extract_dir = path)
         return self

--- a/pyrefinebio/dataset.py
+++ b/pyrefinebio/dataset.py
@@ -280,9 +280,12 @@ class Dataset(Base):
 
         return self
 
-    def extract(self):
+    def extract(self, path):
         """Extract a downloaded Dataset
 
+        Parameters:
+            path (str): the path that the Dataset should be extracted to
+            
         Returns:
             Dataset
         """
@@ -292,5 +295,5 @@ class Dataset(Base):
                 "Make sure you have successfully downloaded the Dataset before extracting."
             )
 
-        shutil.unpack_archive(self._downloaded_path)
+        shutil.unpack_archive(self._downloaded_path, extract_dir = path)
         return self


### PR DESCRIPTION
### Problem 

This is to potentially close #71 and have downloaded files extract to the `path` specified by the user as the docs have me believe is what was intended to happen. 

### Approach 

I added `path` as a parameter to both extract functions and set `extract_dir = path` in the `shutil.unpack_archive`. 

Then I ran `python -m unittest discover tests -b` as the README said to do. I got three errors, but I also got those same three errors on the master branch, so I don't think they are related to the changes I made here. 

That being said, even though the changes didn't cause errors, I don't know if this will work correctly and I don't know how to test if it will fix #71. 

Also don't even know if I am correct that #71 is a problem. ¯\_(ツ)_/¯ 

### Notes reviewers

You should look into my changes more carefully and make sure that they work. I am a Python newb and don't know what I'm doing. Also not very familiar with this code base. But I wanted to take a whack at it because I'd like this to work how the docs described it. 