### PR TITLE
Initialize contributed_keywords

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyrefinebio/sample.py
+++ b/pyrefinebio/sample.py
@@ -113,6 +113,7 @@ class Sample(Base):
         self.created_at = parse_date(created_at)
         self.last_modified = parse_date(last_modified)
         self.contributed_metadata = contributed_metadata
+        self.contributed_keywords = contributed_keywords
 
         self.original_files = (
             [prb_original_file.OriginalFile(id=file_id) for file_id in original_files]
@@ -136,11 +137,7 @@ class Sample(Base):
         self.most_recent_quant_file = most_recent_quant_file
         self.experiment_accession_codes = experiment_accession_codes
         self.experiments = experiments
-
-        # Avoid initializing every Sample with the sample empty list as a default
-        if not contributed_keywords:
-            contributed_keywords = []
-
+        
     @property
     def experiments(self):
         if not self._experiments:


### PR DESCRIPTION
The `Sample.contributed_keywords` property was not being properly initialized, so this PR fixes that.

I chose to leave the default value as `None` rather than initializing it as an empty list, as it seemed like that would be fine for most use cases, and is consistent with the current behavior of `contributed_metadata`, which is now initialized as `None` rather than an empty dictionary.
