### PR TITLE
Add API request rate limit

### DIFF
--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -2,6 +2,9 @@ import json
 import shutil
 
 import requests
+from ratelimiter import RateLimiter as rate_limit
+from requests.exceptions import ConnectionError
+
 from pyrefinebio.config import Config
 from pyrefinebio.exceptions import (
     BadRequest,
@@ -12,13 +15,16 @@ from pyrefinebio.exceptions import (
     NotFound,
     ServerError,
 )
-from requests.exceptions import ConnectionError
 
 
+CONFIG = Config()
+
+
+# Rate limit the API requests per second.
+@rate_limit(max_calls=CONFIG.api_calls_per_second, period=1)
 def request(method, url, params=None, payload=None):
     try:
-        config = Config()
-        headers = {"Content-Type": "application/json", "API-KEY": config.token}
+        headers = {"Content-Type": "application/json", "API-KEY": CONFIG.token}
 
         if payload:
             payload = json.dumps(payload)

--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -19,7 +19,7 @@ from pyrefinebio.exceptions import (
 CONFIG = Config()
 
 # Rate limit the API requests per second.
-limiter = Limiter(RequestRate(CONFIG.api_calls_per_second, Duration.SECOND))
+limiter = Limiter(RequestRate(CONFIG.api_max_calls_per_second, Duration.SECOND))
 
 
 @limiter.ratelimit("refinebio", delay=True)

--- a/pyrefinebio/api_interface.py
+++ b/pyrefinebio/api_interface.py
@@ -2,7 +2,7 @@ import json
 import shutil
 
 import requests
-from ratelimiter import RateLimiter as rate_limit
+from pyrate_limiter import Duration, Limiter, RequestRate
 from requests.exceptions import ConnectionError
 
 from pyrefinebio.config import Config
@@ -16,12 +16,13 @@ from pyrefinebio.exceptions import (
     ServerError,
 )
 
-
 CONFIG = Config()
 
-
 # Rate limit the API requests per second.
-@rate_limit(max_calls=CONFIG.api_calls_per_second, period=1)
+limiter = Limiter(RequestRate(CONFIG.api_calls_per_second, Duration.SECOND))
+
+
+@limiter.ratelimit("refinebio", delay=True)
 def request(method, url, params=None, payload=None):
     try:
         headers = {"Content-Type": "application/json", "API-KEY": CONFIG.token}

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -25,10 +25,11 @@ class Config:
 
             environment variable: `REFINEBIO_BASE_URL`
 
-        api_calls_per_second:
-            The refine.bio API calls per second limit
+        api_max_calls_per_second:
+            The refine.bio API calls per second limit. This defaults to the API's rate limit
+            which is enforced per IP address.
 
-            environment variable: `REFINEBIO_API_CALLS_PER_SECOND`
+            environment variable: `REFINEBIO_API_MAX_CALLS_PER_SECOND`
 
     These config values can be modified directly in code, but it recommended that you
     set them by using environment variables, by modifying them in Config file, or by
@@ -40,7 +41,7 @@ class Config:
 
         token: foo-bar-baz
         base_url: https://api.refine.bio/v1/
-        api_calls_per_second: 10
+        api_max_calls_per_second: 10
     """
 
     _instance = None
@@ -71,9 +72,9 @@ class Config:
             cls.base_url = os.getenv("REFINEBIO_BASE_URL") or config.get(
                 "base_url", "https://api.refine.bio/v1/"
             )
-            cls.api_calls_per_second = int(
-                os.getenv("REFINEBIO_API_CALLS_PER_SECOND")
-                or config.get("api_calls_per_second", 10)
+            cls.api_max_calls_per_second = int(
+                os.getenv("REFINEBIO_API_MAX_CALLS_PER_SECOND")
+                or config.get("api_max_calls_per_second", 10)
             )
 
         return cls._instance
@@ -87,7 +88,7 @@ class Config:
         config = {
             "token": self.token,
             "base_url": self.base_url,
-            "api_calls_per_second": self.api_calls_per_second,
+            "api_max_calls_per_second": self.api_max_calls_per_second,
         }
 
         with open(self.config_file, "w") as config_file:

--- a/pyrefinebio/config.py
+++ b/pyrefinebio/config.py
@@ -15,15 +15,20 @@ class Config:
     pyrefinebio's configurable values are:
 
         token:
-            The refine.bio api token that is used when making requests
+            The refine.bio API token that is used when making requests
 
             environment variable: `REFINEBIO_TOKEN`
 
         base_url:
-            The base url for the refine.bio api that should be used
+            The base url for the refine.bio API that should be used
             when making requests. The default is `https://api.refine.bio/v1/`
 
             environment variable: `REFINEBIO_BASE_URL`
+
+        api_calls_per_second:
+            The refine.bio API calls per second limit
+
+            environment variable: `REFINEBIO_API_CALLS_PER_SECOND`
 
     These config values can be modified directly in code, but it recommended that you
     set them by using environment variables, by modifying them in Config file, or by
@@ -35,6 +40,7 @@ class Config:
 
         token: foo-bar-baz
         base_url: https://api.refine.bio/v1/
+        api_calls_per_second: 10
     """
 
     _instance = None
@@ -65,6 +71,10 @@ class Config:
             cls.base_url = os.getenv("REFINEBIO_BASE_URL") or config.get(
                 "base_url", "https://api.refine.bio/v1/"
             )
+            cls.api_calls_per_second = int(
+                os.getenv("REFINEBIO_API_CALLS_PER_SECOND")
+                or config.get("api_calls_per_second", 10)
+            )
 
         return cls._instance
 
@@ -74,7 +84,11 @@ class Config:
         The default path for this file is `~/.refinebio.yaml`
         but it can be set using the environment variable `REFINEBIO_CONFIG_FILE`.
         """
-        config = {"token": self.token, "base_url": self.base_url}
+        config = {
+            "token": self.token,
+            "base_url": self.base_url,
+            "api_calls_per_second": self.api_calls_per_second,
+        }
 
         with open(self.config_file, "w") as config_file:
             yaml.dump(config, config_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
 iso8601==0.1.16
+pyrate-limiter==2.10.0
 pytimeparse==1.1.8
 PyYAML==5.3.1
-ratelimiter==1.2.0.post0
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click==7.1.2
 iso8601==0.1.16
-PyYAML==5.3.1
-requests==2.24.0
 pytimeparse==1.1.8
+PyYAML==5.3.1
+ratelimiter==1.2.0.post0
+requests==2.24.0

--- a/tests/test_api_interface.py
+++ b/tests/test_api_interface.py
@@ -1,3 +1,5 @@
+import threading
+import time
 import unittest
 from unittest.mock import patch
 
@@ -5,6 +7,26 @@ import pyrefinebio
 from pyrefinebio.exceptions import BadRequest, NotFound
 from tests.custom_assertions import CustomAssertions
 from tests.mocks import MockResponse
+
+
+def mock_200_request(method, url, **kwargs):
+    experiment = {
+        "title": "TEST_EXPERIMENT",
+    }
+    sample = {
+        "accession_code": "TEST_SAMPLE",
+    }
+
+    if url == "https://api.refine.bio/v1/experiments/UNDER/":
+        experiment["samples"] = [{"accession_code": str(i)} for i in range(9)]
+        return MockResponse(experiment, url)
+
+    if url == "https://api.refine.bio/v1/experiments/OVER/":
+        experiment["samples"] = [{"accession_code": str(i)} for i in range(10)]
+        return MockResponse(experiment, url)
+
+    if url.startswith("https://api.refine.bio/v1/samples/"):
+        return MockResponse(sample, url, 200)
 
 
 def mock_400_request(method, url, **kwargs):
@@ -20,6 +42,16 @@ def mock_404_request(method, url, **kwargs):
 
 
 class ApiInterfaceTests(unittest.TestCase, CustomAssertions):
+    PERIOD_SECONDS = 1
+
+    class Timer:
+        def __enter__(self):
+            self.start = time.time()
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            self.duration = time.time() - self.start
+
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_400_request)
     def test_400(self, mock_request):
         with self.assertRaises(BadRequest):
@@ -29,3 +61,25 @@ class ApiInterfaceTests(unittest.TestCase, CustomAssertions):
     def test_404(self, mock_request):
         with self.assertRaises(NotFound):
             pyrefinebio.Organism.get("GORILLA")
+
+    @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_200_request)
+    def test_rate_limit(self, mock_request):
+        time.sleep(self.PERIOD_SECONDS)
+        threads = []
+        with self.Timer() as timer:
+            for sample in pyrefinebio.Experiment.get("UNDER").samples:
+                t = threading.Thread(target=lambda: sample.contributed_keywords)
+                threads.append(t)
+                t.start()
+            [t.join() for t in threads]
+        self.assertLessEqual(timer.duration, self.PERIOD_SECONDS, timer.duration)
+
+        time.sleep(self.PERIOD_SECONDS)
+        threads = []
+        with self.Timer() as timer:
+            for sample in pyrefinebio.Experiment.get("OVER").samples:
+                t = threading.Thread(target=lambda: sample.contributed_keywords)
+                threads.append(t)
+                t.start()
+            [t.join() for t in threads]
+        self.assertGreater(timer.duration, self.PERIOD_SECONDS, timer.duration)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -55,7 +55,7 @@ class TokenTests(unittest.TestCase, CustomAssertions):
             {
                 "token": token.id,
                 "base_url": "https://api.refine.bio/v1/",
-                "api_calls_per_second": 10,
+                "api_max_calls_per_second": 10,
             },
             "file",
         )

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -52,7 +52,12 @@ class TokenTests(unittest.TestCase, CustomAssertions):
 
         mock_open.assert_called_with("test", "w")
         mock_yaml.assert_called_with(
-            {"token": token.id, "base_url": "https://api.refine.bio/v1/"}, "file"
+            {
+                "token": token.id,
+                "base_url": "https://api.refine.bio/v1/",
+                "api_calls_per_second": 10,
+            },
+            "file",
         )
 
     @patch("pyrefinebio.api_interface.requests.request", side_effect=mock_request)


### PR DESCRIPTION
Resolves #83 

Add API request rate limit using ratelimiter.

Add `api_calls_per_second` to the config. Use 10 as a default if neither `REFINEBIO_API_CALLS_PER_SECOND` env variable nor `api_calls_per_second` config item is available.