### PR TITLE
Add pyrate-limiter to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "Operating System :: OS Independent",  # not sure if this is actually true - we should probably test on windows!
     ],
     python_requires=">=3.6",
-    install_requires=["iso8601", "PyYAML", "requests", "Click", "pytimeparse"],
+    install_requires=["iso8601", "PyYAML", "requests", "Click", "pytimeparse", "pyrate-limiter<3"],
     entry_points="""
         [console_scripts]
         refinebio=pyrefinebio.script:cli


### PR DESCRIPTION
Does what it says, though I may not have the syntax quite right. We need to specify version < 3, because the class names have changed.

Feel free to replace this with something more correct!