### PR TITLE
88 - Quantile Normalize Default Inconsistency

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -68,7 +68,7 @@ The :code:`experiments` option is just a space separated list of Experiment acce
 
 .. code-block:: shell
 
-    $ refinebio download-datset --experiments "<Experiment 1 Accession Code> <Experiment 2 Accession Code>"
+    $ refinebio download-dataset --experiments "<Experiment 1 Accession Code> <Experiment 2 Accession Code>"
 
 
 * **dataset-dict** should be used when you want to specify specific Samples to be included in the Dataset. However, you can pass in "ALL" instead of specific Sample accession codes to add all downloadable Samples associated with that Experiment to the Dataset.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -88,7 +88,7 @@ You can also pass in other optional command options to alter the Dataset itself 
 
 * **transformation** - Can be used to change the transformation of the Dataset. The default is "NONE", and the other available choices are "MINMAX" and "STANDARD". For more information on Dataset transformation check out `Gene transformations`_. 
 
-* **skip-quantile-normalization** - Can be used to choose whether or not quantile normalization is skipped for RNA-seq Samples. For more information check out `Quantile normalization`_.
+* **skip-quantile-normalization** - Can be used to disable quantile normalization for RNA-seq Samples, which is performed by default. For more information check out `Quantile normalization`_.
 
 * **extract** - Can be used to choose whether the downloaded zip file should be automatically extracted. It will automatically extract to the same location that you passed in as :code:`path`. So if :code:`path` is a zip file: :code:`./path/to/dataset.zip` it will be extracted to the dir :code:`./path/to/dataset/`, if :code:`path` is a dir: :code:`./path/to/dir/` it will be extracted to :code:`./path/to/dir/[generated-file-name]/`. By default, :code:`extract` is False. 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -109,7 +109,7 @@ You can also pass in other optional parameters to alter the Dataset itself and t
 
 * **transformation** `(str)` - Can be used to change the transformation of the Dataset. The default is "NONE", and the other available choices are "MINMAX" and "STANDARD". For more information on Dataset transformation check out `Gene transformations`_. 
 
-* **skip_quantile_normalization** `(bool)` - Can be used to choose whether or not quantile normalization is skipped for RNA-seq Samples. For more information check out `Quantile normalization`_.
+* **skip_quantile_normalization** `(bool)` - Can be used to disable quantile normalization for RNA-seq Samples, which is performed by default. For more information check out `Quantile normalization`_.
 
 * **extract** `(bool)` - Can be used to choose whether the downloaded zip file should be automatically extracted. It will automatically extract to the same location that you passed in as :code:`path`. So if :code:`path` is a zip file: :code:`./path/to/dataset.zip` it will be extracted to the dir :code:`./path/to/dataset/`, if :code:`path` is a dir: :code:`./path/to/dir/` it will be extracted to :code:`./path/to/dir/[generated-file-name]/`. By default, :code:`extract` is False. 
 

--- a/pyrefinebio/high_level_functions.py
+++ b/pyrefinebio/high_level_functions.py
@@ -93,7 +93,8 @@ def download_dataset(
         transformation (str): the transformation for the dataset - `NONE`, `MINMAX`, or `STANDARD`
 
         skip_quantile_normalization (bool): control whether or not the dataset should skip quantile
-                                            normalization for RNA-seq Samples
+                                            normalization for RNA-seq Samples. Quantile normalization
+                                            is performed by default.
 
         quant_sf_only (bool): include only quant.sf files in the generated dataset.
 

--- a/pyrefinebio/script.py
+++ b/pyrefinebio/script.py
@@ -106,7 +106,7 @@ def describe(entity=None):
     "--skip-quantile-normalization",
     default=False,
     type=click.BOOL,
-    help="Control whether the Dataset should skip quantile normalization for RNA-seq Samples",
+    help="Control whether the Dataset should skip quantile normalization for RNA-seq Samples. Quantile normalization is performed by default.",
 )
 @click.option(
     "--timeout",


### PR DESCRIPTION
This PR is related to Issue https://github.com/AlexsLemonade/refinebio-py/issues/88

### Context

There are five steps associated with downloading `Datasets` in `pyrefinebio`:
1. creating the `Dataset` 
-> `dataset = Dataset(...)`
2. processing it 
-> `dataset.process()`
3. waiting for it to finish 
-> `dataset.check()`
4. downloading it 
-> `dataset.download()`
5. extracting it (optional) 
->`dataset.extract()`

There are three workflows which enable the downloading of datasets with `pyrefinebio` (after a token has been created):
1. Using the CLI - `refinebio download-dataset ...`
-> This takes care of all of the steps in one commands.
2. Using the exposed high level functions - `pyrefinebio.download_dataset(...)`
-> This is the recommended way to use the library programmatically, taking care of all steps in one command.
3. Using the exposed classes manually - `dataset = pyrefinebio.Dataset()`, `dataset.add_samples(...)`, `dataset.process()`, ...
-> This is called the `Advanced Dataset Usage` in the documentation, where each of the five steps must be performed manually.

### Conclusion

Workflows 1 and 2 both have `download` commands which call `high_level_functions::download_dataset` under the hood. The first thing that these commands do is build a `Dataset` object by calling the class' constructor with the arguments passed into `high_level_function::download_dataset` by the user. 

`high_level_functions::download_dataset` has the default parameter of `skip_quantile_normalization=False`. When the `Dataset` instance is created, this parameter is negated to properly set the class' `quantile_normalize` attribute, as follows `quantile_normalize=(not skip_quantile_normalization)`. If `--skip-quantile-normalization` is passed to the CLI command, or `skip_quantile_normalization=True` is passed to `pyrefinebio.download_dataset(...)`, then the default is overridden, and the value passed is as follows `Dataset(..., quantile_normalization=False, ...)`.

When using workflow 3, however, the constructor assigns all parameters with a default `None` value (including `quantile_normalize=None`), ultimately making `quantile_normalize` falsy.

In conclusion, there is an inconsistency between these workflows, namely that `quantile_normalize` defaults to `True` in workflows 1 and 2, and defaults to `None` (falsy) in workflow 3.

This can be addressed by either:
- Updating the documentation to clarify this.
- Changing how defaults to defined parameters are assigned in the `Dataset` constructor.

In the meantime I've made a few edits to documentation to clarify how `skip_quantile_normalization` works with workflows 1 and 2.